### PR TITLE
fix(ui): don't seek when editing time events

### DIFF
--- a/packages/ui/src/hooks/useDrag.ts
+++ b/packages/ui/src/hooks/useDrag.ts
@@ -33,6 +33,15 @@ export function useDrag(
   );
 
   useDocumentEvent(
+    'click',
+    useCallback(event => {
+      event.stopPropagation();
+    }, []),
+    isDragging,
+    true,
+  );
+
+  useDocumentEvent(
     'mousemove',
     useCallback(
       event => {


### PR DESCRIPTION
The propagation of click events will now be stopped if something is being dragged.
This prevents the timeline from seeking when editing a time event.