### PR TITLE
fix(core): keep falsy values with deepTween

### DIFF
--- a/packages/core/src/tweening/tweenFunctions.test.ts
+++ b/packages/core/src/tweening/tweenFunctions.test.ts
@@ -77,6 +77,10 @@ describe('deepTween', () => {
     expect(deepTween({foo: 5}, {}, 0)).toEqual({foo: 5});
   });
 
+  test('retains properties with falsy values', () => {
+    expect(deepTween({x: 0, y: 10}, {x: 0, y: 20}, 0.5)).toEqual({x: 0, y: 15});
+  });
+
   test('waits to add new values to a map until a value of 1', () => {
     expect(deepTween({}, {foo: 5}, 3 / 5)).toEqual({});
     expect(deepTween({}, {foo: 5}, 0)).toEqual({});

--- a/packages/core/src/tweening/tweenFunctions.ts
+++ b/packages/core/src/tweening/tweenFunctions.ts
@@ -108,7 +108,7 @@ export function deepTween(from: any, to: any, value: number): any {
         const result = new Map();
         for (const key of new Set([...from.keys(), ...to.keys()])) {
           const inter = deepTween(from.get(key), to.get(key), value);
-          if (inter) result.set(key, inter);
+          if (inter !== undefined) result.set(key, inter);
         }
         return toObject ? Object.fromEntries(result) : result;
       }


### PR DESCRIPTION
This PR fixes a bug with `deepTween` that was removing all falsy properties.
I.e. tweening between `{x: 0, y: 10}` and `{x: 0, y: 20}` would result in the `x` property missing.