### PR TITLE
feat: simplify size access

### DIFF
--- a/packages/2d/src/components/Circle.ts
+++ b/packages/2d/src/components/Circle.ts
@@ -16,8 +16,7 @@ export class Circle extends Node<CircleProps> {
     context.save();
     this.transformContext(context);
 
-    const width = this.width();
-    const height = this.height();
+    const {width, height} = this.computedLayout();
 
     context.save();
     context.fillStyle = this.fill();

--- a/packages/2d/src/components/Rect.ts
+++ b/packages/2d/src/components/Rect.ts
@@ -16,8 +16,7 @@ export class Rect extends Node<RectProps> {
     context.save();
     this.transformContext(context);
 
-    const width = this.width();
-    const height = this.height();
+    const {width, height} = this.computedLayout();
 
     context.save();
     context.fillStyle = this.fill();

--- a/packages/2d/src/decorators/property.ts
+++ b/packages/2d/src/decorators/property.ts
@@ -129,7 +129,7 @@ export function createProperty<
  * The class using this decorator can implement the following methods:
  * - `get[PropertyName]` - A property getter.
  * - `get[PropertyName]` - A property setter.
- * - `tween[PropertyName]` - a tween provider.
+ * - `tween[PropertyName]` - A tween provider.
  *
  * See the {@link PropertyOwner} type for more detailed method signatures.
  *

--- a/packages/2d/src/layout/types.ts
+++ b/packages/2d/src/layout/types.ts
@@ -18,4 +18,7 @@ export type AlignItems =
   | 'space-between'
   | 'space-around';
 
-export type LayoutMode = 'disabled' | 'enabled' | 'root' | 'pop' | null;
+export type ResolvedLayoutMode = 'disabled' | 'enabled' | 'root' | 'pop';
+export type LayoutMode = ResolvedLayoutMode | null;
+
+export type Length = number | `${number}%` | null;

--- a/packages/2d/src/scenes/TwoDView.ts
+++ b/packages/2d/src/scenes/TwoDView.ts
@@ -1,10 +1,11 @@
 import {Node} from '../components';
 
-export class TwoDView extends Node<any> {
+export class TwoDView extends Node {
   private static frameID = 'motion-canvas-2d-frame';
 
   public constructor() {
-    super({layout: {width: 1920, height: 1080}, mode: 'none'});
+    // TODO Sync with the project size
+    super({width: 1920, height: 1080});
 
     let frame = document.querySelector<HTMLIFrameElement>(
       `#${TwoDView.frameID}`,
@@ -28,10 +29,7 @@ export class TwoDView extends Node<any> {
   }
 
   public override render(context: CanvasRenderingContext2D) {
-    this.x();
-    this.y();
-    this.width();
-    this.height();
+    this.computedLayout();
     super.render(context);
   }
 }


### PR DESCRIPTION
This PR merges `Layout.width` and `Node.width` into one. The same signal is used no matter the layout mode.

The Node class also handles proper tweening of widths:
```ts
node.width(null); // set width to auto
yield* node.width('100%', 2); // tween from auto to 100%
```

The `node.width()` getter returns the desired width again. The actual width calculated by the layout engine can be access by `node.computedWidth()`.

All of the above applies to `height` and `size` properties as well.