### PR TITLE
feat: simplify size access further

### DIFF
--- a/packages/core/src/utils/createSignal.ts
+++ b/packages/core/src/utils/createSignal.ts
@@ -29,10 +29,7 @@ export interface SignalTween<TValue> {
   ): ThreadGenerator;
 }
 
-export interface Signal<TValue, TReturn = void>
-  extends SignalSetter<TValue, TReturn>,
-    SignalGetter<TValue>,
-    SignalTween<TValue> {
+export interface SignalUtils<TReturn> {
   /**
    * Reset the signal to its initial value (if one has been set).
    *
@@ -63,6 +60,12 @@ export interface Signal<TValue, TReturn = void>
    */
   save(): TReturn;
 }
+
+export interface Signal<TValue, TReturn = void>
+  extends SignalSetter<TValue, TReturn>,
+    SignalGetter<TValue>,
+    SignalTween<TValue>,
+    SignalUtils<TReturn> {}
 
 const collectionStack: DependencyContext[] = [];
 


### PR DESCRIPTION
All size getters (`node.width()`, `node.height()`, etc.) now return the computed size. 
This is more in line with how position getters like `node.x()` and `node.position()` work.
It's still possible to access the desired size using `node.customWidth()`, etc.