### PR TITLE
feat: introduce basic caching

### DIFF
--- a/packages/2d/src/components/Circle.ts
+++ b/packages/2d/src/components/Circle.ts
@@ -3,7 +3,7 @@ import {Shape} from './Shape';
 export class Circle extends Shape {
   protected getPath(): Path2D {
     const path = new Path2D();
-    const {width, height} = this.computedLayout();
+    const {width, height} = this.computedSize();
     path.ellipse(0, 0, width / 2, height / 2, 0, 0, Math.PI * 2);
     return path;
   }

--- a/packages/2d/src/components/Rect.ts
+++ b/packages/2d/src/components/Rect.ts
@@ -3,7 +3,7 @@ import {Shape} from './Shape';
 export class Rect extends Shape {
   protected getPath(): Path2D {
     const path = new Path2D();
-    const {width, height} = this.computedLayout();
+    const {width, height} = this.computedSize();
     path.rect(-width / 2, -height / 2, width, height);
     return path;
   }

--- a/packages/2d/src/components/Shape.ts
+++ b/packages/2d/src/components/Shape.ts
@@ -1,8 +1,8 @@
 import {Node, NodeProps} from './Node';
 import {Gradient, Pattern} from '../partials';
-import {compound, property} from '../decorators';
+import {compound, computed, property} from '../decorators';
 import {Signal} from '@motion-canvas/core/lib/utils';
-import {Vector2} from '@motion-canvas/core/lib/types';
+import {Vector2, Rect, rect} from '@motion-canvas/core/lib/types';
 import {vector2dLerp} from '@motion-canvas/core/lib/tweening';
 
 export type CanvasStyle = null | string | Gradient | Pattern;
@@ -10,6 +10,7 @@ export type CanvasStyle = null | string | Gradient | Pattern;
 export interface ShapeProps extends NodeProps {
   fill?: CanvasStyle;
   stroke?: CanvasStyle;
+  strokeFirst?: boolean;
   lineWidth?: number;
   lineJoin?: CanvasLineJoin;
   lineCap?: CanvasLineCap;
@@ -27,6 +28,8 @@ export abstract class Shape<T extends ShapeProps = ShapeProps> extends Node<T> {
   public declare readonly fill: Signal<CanvasStyle, this>;
   @property(null)
   public declare readonly stroke: Signal<CanvasStyle, this>;
+  @property(false)
+  public declare readonly strokeFirst: Signal<boolean, this>;
   @property(0)
   public declare readonly lineWidth: Signal<number, this>;
   @property('miter')
@@ -49,6 +52,16 @@ export abstract class Shape<T extends ShapeProps = ShapeProps> extends Node<T> {
   @property(undefined, vector2dLerp)
   public declare readonly shadowOffset: Signal<Vector2, this>;
 
+  @computed()
+  protected hasShadow(): boolean {
+    return (
+      !!this.shadowColor() ||
+      !!this.shadowOffsetX() ||
+      !!this.shadowOffsetY() ||
+      !!this.shadowBlur()
+    );
+  }
+
   protected parseCanvasStyle(
     style: CanvasStyle,
     context: CanvasRenderingContext2D,
@@ -65,15 +78,16 @@ export abstract class Shape<T extends ShapeProps = ShapeProps> extends Node<T> {
     return style.canvasPattern(context) ?? '';
   }
 
-  protected applyFill(context: CanvasRenderingContext2D) {
-    context.fillStyle = this.parseCanvasStyle(this.fill(), context);
+  protected applyShadow(context: CanvasRenderingContext2D) {
+    // TODO Consider accounting for transparency when drawing from cache.
     context.shadowColor = this.shadowColor();
     context.shadowBlur = this.shadowBlur();
     context.shadowOffsetX = this.shadowOffsetX();
     context.shadowOffsetY = this.shadowOffsetY();
   }
 
-  protected applyStroke(context: CanvasRenderingContext2D) {
+  protected applyStyle(context: CanvasRenderingContext2D) {
+    context.fillStyle = this.parseCanvasStyle(this.fill(), context);
     context.strokeStyle = this.parseCanvasStyle(this.stroke(), context);
     context.lineWidth = this.lineWidth();
     context.lineJoin = this.lineJoin();
@@ -82,25 +96,45 @@ export abstract class Shape<T extends ShapeProps = ShapeProps> extends Node<T> {
     context.lineDashOffset = this.lineDashOffset();
   }
 
-  public override render(context: CanvasRenderingContext2D) {
-    context.save();
-    this.transformContext(context);
-
+  protected override draw(context: CanvasRenderingContext2D, cache = false) {
     const path = this.getPath();
     context.save();
-    this.applyFill(context);
-    context.fill(path);
-    context.restore();
-    context.save();
-    this.applyStroke(context);
-    context.stroke(path);
+    this.applyStyle(context);
+    if (!cache) {
+      this.applyShadow(context);
+    }
+    if (this.strokeFirst()) {
+      context.stroke(path);
+      context.fill(path);
+    } else {
+      context.fill(path);
+      context.stroke(path);
+    }
     context.restore();
 
-    for (const child of this.children()) {
-      child.render(context);
+    super.draw(context, cache);
+  }
+
+  protected requiresCache(): boolean {
+    const hasCompositeEffect = this.opacity() < 1 || this.hasShadow();
+    let separateComponents = this.children().length;
+    if (this.stroke()) {
+      separateComponents++;
+    }
+    if (this.fill()) {
+      separateComponents++;
     }
 
-    context.restore();
+    return this.cache() || (hasCompositeEffect && separateComponents > 1);
+  }
+
+  protected override setupDrawFromCache(context: CanvasRenderingContext2D) {
+    this.applyShadow(context);
+    super.setupDrawFromCache(context);
+  }
+
+  protected override getCacheRect(): Rect {
+    return rect.expand(super.getCacheRect(), this.lineWidth() / 2);
   }
 
   protected abstract getPath(): Path2D;

--- a/packages/2d/src/scenes/TwoDView.ts
+++ b/packages/2d/src/scenes/TwoDView.ts
@@ -29,7 +29,8 @@ export class TwoDView extends Node {
   }
 
   public override render(context: CanvasRenderingContext2D) {
-    this.computedLayout();
+    this.computedSize();
+    this.computedPosition();
     super.render(context);
   }
 }

--- a/packages/core/src/types/Rect.ts
+++ b/packages/core/src/types/Rect.ts
@@ -1,6 +1,85 @@
+import {Vector2} from './Vector';
+import {transformPoint, transformVector} from './Matrix';
+
 export interface Rect {
   x: number;
   y: number;
   width: number;
   height: number;
 }
+
+export function rect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): Rect {
+  return {x, y, width, height};
+}
+
+export interface rect {
+  fromPoints: (...points: Vector2[]) => Rect;
+  topLeft: (rect: Rect) => Vector2;
+  topRight: (rect: Rect) => Vector2;
+  bottomLeft: (rect: Rect) => Vector2;
+  bottomRight: (rect: Rect) => Vector2;
+  transform: (rect: Rect, matrix: DOMMatrix) => Rect;
+  expand: (rect: Rect, amount: number) => Rect;
+}
+
+rect.fromPoints = (...points: Vector2[]) => {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const point of points) {
+    if (point.x > maxX) {
+      maxX = point.x;
+    }
+    if (point.x < minX) {
+      minX = point.x;
+    }
+    if (point.y > maxY) {
+      maxY = point.y;
+    }
+    if (point.y < minY) {
+      minY = point.y;
+    }
+  }
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+};
+
+rect.topLeft = (rect: Rect) => ({x: rect.x, y: rect.y});
+rect.topRight = (rect: Rect) => ({x: rect.x + rect.width, y: rect.y});
+rect.bottomLeft = (rect: Rect) => ({x: rect.x, y: rect.y + rect.height});
+rect.bottomRight = (rect: Rect) => ({
+  x: rect.x + rect.width,
+  y: rect.y + rect.height,
+});
+
+rect.transform = (rect: Rect, matrix: DOMMatrix) => {
+  const position = transformPoint(rect, matrix);
+  const size = transformVector({x: rect.width, y: rect.height}, matrix);
+
+  return {
+    ...position,
+    width: size.x,
+    height: size.y,
+  };
+};
+
+rect.expand = (rect: Rect, amount: number) => {
+  return {
+    x: rect.x - amount,
+    y: rect.y - amount,
+    width: rect.width + amount * 2,
+    height: rect.height + amount * 2,
+  };
+};


### PR DESCRIPTION
Allows the contents of a node to be cached in a separate canvas which is then used for rendering.
It makes it possible to correctly composite transparency, shadows, and filters.