### PR TITLE
feat: add advanced caching

### DIFF
--- a/packages/2d/src/decorators/property.ts
+++ b/packages/2d/src/decorators/property.ts
@@ -73,7 +73,10 @@ export function createProperty<
     setter = signal;
   } else {
     getter = originalGetter.bind(node);
-    setter = originalSetter.bind(node);
+    setter = (...args) => {
+      originalSetter.apply(node, args);
+      return node;
+    };
   }
 
   const handler = <Property<TSetterValue, TGetterValue, TNode>>(

--- a/packages/2d/src/scenes/TwoDScene.ts
+++ b/packages/2d/src/scenes/TwoDScene.ts
@@ -1,4 +1,8 @@
-import {GeneratorScene, Scene} from '@motion-canvas/core/lib/scenes';
+import {
+  GeneratorScene,
+  Scene,
+  SceneRenderEvent,
+} from '@motion-canvas/core/lib/scenes';
 import {TwoDView} from './TwoDView';
 
 export class TwoDScene extends GeneratorScene<TwoDView> {
@@ -13,11 +17,17 @@ export class TwoDScene extends GeneratorScene<TwoDView> {
     canvas: HTMLCanvasElement,
   ): void {
     context.save();
+    this.renderLifecycle.dispatch([SceneRenderEvent.BeforeRender, context]);
+    context.save();
+    this.renderLifecycle.dispatch([SceneRenderEvent.BeginRender, context]);
     this.view.render(context);
+    this.renderLifecycle.dispatch([SceneRenderEvent.FinishRender, context]);
+    context.restore();
+    this.renderLifecycle.dispatch([SceneRenderEvent.AfterRender, context]);
     context.restore();
   }
 
-  public reset(previousScene?: Scene): Promise<void> {
+  public override reset(previousScene?: Scene): Promise<void> {
     this.view.removeChildren();
     return super.reset(previousScene);
   }

--- a/packages/2d/src/scenes/TwoDView.ts
+++ b/packages/2d/src/scenes/TwoDView.ts
@@ -5,7 +5,7 @@ export class TwoDView extends Node {
 
   public constructor() {
     // TODO Sync with the project size
-    super({width: 1920, height: 1080});
+    super({width: 1920, height: 1080, composite: true});
 
     let frame = document.querySelector<HTMLIFrameElement>(
       `#${TwoDView.frameID}`,
@@ -29,8 +29,39 @@ export class TwoDView extends Node {
   }
 
   public override render(context: CanvasRenderingContext2D) {
+    const currentMatrix = this.localToParent();
+    const customMatrix = context.getTransform();
+    if (
+      customMatrix.a !== currentMatrix.a ||
+      customMatrix.b !== currentMatrix.b ||
+      customMatrix.c !== currentMatrix.c ||
+      customMatrix.d !== currentMatrix.d ||
+      customMatrix.e !== currentMatrix.e ||
+      customMatrix.f !== currentMatrix.f
+    ) {
+      this.x(customMatrix.m41)
+        .y(customMatrix.m42)
+        .scaleX(
+          Math.sqrt(
+            customMatrix.m11 * customMatrix.m11 +
+              customMatrix.m12 * customMatrix.m12,
+          ),
+        )
+        .scaleY(
+          Math.sqrt(
+            customMatrix.m21 * customMatrix.m21 +
+              customMatrix.m22 * customMatrix.m22,
+          ),
+        )
+        .rotation(Math.atan2(customMatrix.m12, customMatrix.m11));
+    }
+
     this.computedSize();
     this.computedPosition();
     super.render(context);
+  }
+
+  protected transformContext(context: CanvasRenderingContext2D) {
+    // do nothing
   }
 }

--- a/packages/core/src/types/Matrix.ts
+++ b/packages/core/src/types/Matrix.ts
@@ -22,3 +22,7 @@ export function transformAngle(angle: number, matrix: DOMMatrix) {
   );
   return (Math.atan2(vector.y, vector.x) * 180) / Math.PI;
 }
+
+export function transformScalar(scalar: number, matrix: DOMMatrix) {
+  return Math.sqrt(matrix.m11 * matrix.m11 + matrix.m12 * matrix.m12) * scalar;
+}

--- a/packages/core/src/types/Rect.ts
+++ b/packages/core/src/types/Rect.ts
@@ -19,10 +19,12 @@ export function rect(
 
 export interface rect {
   fromPoints: (...points: Vector2[]) => Rect;
+  fromRects: (...rects: Rect[]) => Rect;
   topLeft: (rect: Rect) => Vector2;
   topRight: (rect: Rect) => Vector2;
   bottomLeft: (rect: Rect) => Vector2;
   bottomRight: (rect: Rect) => Vector2;
+  corners: (rect: Rect) => Vector2[];
   transform: (rect: Rect, matrix: DOMMatrix) => Rect;
   expand: (rect: Rect, amount: number) => Rect;
 }
@@ -56,6 +58,37 @@ rect.fromPoints = (...points: Vector2[]) => {
   };
 };
 
+rect.fromRects = (...rects: Rect[]) => {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const r of rects) {
+    const right = r.x + r.width;
+    if (right > maxX) {
+      maxX = right;
+    }
+    if (r.x < minX) {
+      minX = r.x;
+    }
+    const bottom = r.y + r.height;
+    if (bottom > maxY) {
+      maxY = bottom;
+    }
+    if (r.y < minY) {
+      minY = r.y;
+    }
+  }
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+};
+
 rect.topLeft = (rect: Rect) => ({x: rect.x, y: rect.y});
 rect.topRight = (rect: Rect) => ({x: rect.x + rect.width, y: rect.y});
 rect.bottomLeft = (rect: Rect) => ({x: rect.x, y: rect.y + rect.height});
@@ -63,6 +96,12 @@ rect.bottomRight = (rect: Rect) => ({
   x: rect.x + rect.width,
   y: rect.y + rect.height,
 });
+rect.corners = (value: Rect) => [
+  rect.topLeft(value),
+  rect.topRight(value),
+  rect.bottomRight(value),
+  rect.bottomLeft(value),
+];
 
 rect.transform = (rect: Rect, matrix: DOMMatrix) => {
   const position = transformPoint(rect, matrix);


### PR DESCRIPTION
Caching now accounts for blur and shadow which may expand the required region. The above effects are now transformed to be relative to the closest composite root. 
Normally, units used by these effects would be absolute - they would ignore the transformation matrix entirely.