### PR TITLE
fix: the resolution fields in Rendering no longer reset each other

### DIFF
--- a/packages/ui/src/components/sidebar/Rendering.tsx
+++ b/packages/ui/src/components/sidebar/Rendering.tsx
@@ -73,6 +73,7 @@ export function Rendering() {
           value={width}
           onChange={event => {
             const value = parseInt((event.target as HTMLInputElement).value);
+            const {height} = player.project.getSize();
             player.project.setSize(value, height);
           }}
         />
@@ -83,6 +84,7 @@ export function Rendering() {
           value={height}
           onChange={event => {
             const value = parseInt((event.target as HTMLInputElement).value);
+            const {width} = player.project.getSize();
             player.project.setSize(width, value);
           }}
         />


### PR DESCRIPTION
The `getSize` method did not cause the React component to observe the result, as you would get with `useState`. This caused the component to never receive the new values when after changing them, and upon setting the other value (whichever comes second), it would re-set the first value to its original setting. This is the quickest possible fix.