### PR TITLE
feat: add video node

### DIFF
--- a/packages/2d/src/components/CodeBlock.ts
+++ b/packages/2d/src/components/CodeBlock.ts
@@ -1,5 +1,9 @@
 import {computed, initial, property} from '../decorators';
-import {Signal, SignalValue} from '@motion-canvas/core/lib/utils';
+import {
+  createComputedAsync,
+  Signal,
+  SignalValue,
+} from '@motion-canvas/core/lib/utils';
 import {Shape, ShapeProps} from './Shape';
 import {CodeTree, parse, diff, ready, MorphToken} from 'code-fns';
 import {
@@ -16,6 +20,11 @@ export interface CodeProps extends ShapeProps {
 }
 
 export class CodeBlock extends Shape {
+  private static initialized = createComputedAsync(
+    () => ready().then(() => true),
+    false,
+  );
+
   @initial('')
   @property()
   public declare readonly code: Signal<CodeTree, this>;
@@ -35,9 +44,9 @@ export class CodeBlock extends Shape {
     }
   }
 
-  protected override collectAsyncResources(resources: Promise<any>[]): void {
-    super.collectAsyncResources(resources);
-    resources.push(ready());
+  protected override collectAsyncResources(): void {
+    super.collectAsyncResources();
+    CodeBlock.initialized();
   }
 
   @threadable()
@@ -61,6 +70,8 @@ export class CodeBlock extends Shape {
   }
 
   protected override draw(context: CanvasRenderingContext2D) {
+    if (!CodeBlock.initialized()) return;
+
     this.requestFontUpdate();
     this.applyStyle(context);
     context.font = this.styles.font;

--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -21,6 +21,7 @@ import {
   PossibleVector2,
 } from '@motion-canvas/core/lib/types';
 import {
+  consumePromises,
   createSignal,
   isReactive,
   Reference,
@@ -865,20 +866,17 @@ export class Node implements Promisable<Node> {
    * before continuing the animation.
    */
   public waitForAsyncResources() {
-    const deps: Promise<any>[] = [];
-    this.collectAsyncResources(deps);
-    return Promise.all(deps);
+    this.collectAsyncResources();
+    const promises = consumePromises();
+    return Promise.all(promises.map(handle => handle.promise));
   }
 
   /**
-   * Collect all asynchronous resources used by this node and put them in the
-   * `resources` array.
-   *
-   * @param resources - An array to which resources should be collected.
+   * Collect all asynchronous resources used by this node.
    */
-  protected collectAsyncResources(resources: Promise<any>[]) {
+  protected collectAsyncResources() {
     for (const child of this.children()) {
-      child.collectAsyncResources(resources);
+      child.collectAsyncResources();
     }
   }
 

--- a/packages/2d/src/components/Video.ts
+++ b/packages/2d/src/components/Video.ts
@@ -1,0 +1,211 @@
+import {Rect as RectType} from '@motion-canvas/core/lib/types';
+import {drawImage} from '../utils';
+import {computed, initial, property} from '../decorators';
+import {
+  collectPromise,
+  Signal,
+  SignalValue,
+  useProject,
+  useThread,
+} from '@motion-canvas/core/lib/utils';
+import {View2D} from '../scenes';
+import {PlaybackState} from '@motion-canvas/core';
+import {clamp} from '@motion-canvas/core/lib/tweening';
+import {Rect, RectProps} from './Rect';
+
+export interface VideoProps extends RectProps {
+  src?: SignalValue<string>;
+  alpha?: SignalValue<number>;
+  smoothing?: SignalValue<boolean>;
+  time?: SignalValue<number>;
+  play?: boolean;
+}
+
+export class Video extends Rect {
+  private static readonly pool: Record<string, HTMLVideoElement> = {};
+
+  @property()
+  public declare readonly src: Signal<string, this>;
+
+  @initial(1)
+  @property()
+  public declare readonly alpha: Signal<number, this>;
+
+  @initial(true)
+  @property()
+  public declare readonly smoothing: Signal<boolean, this>;
+
+  @initial(0)
+  @property()
+  protected declare readonly time: Signal<number, this>;
+
+  @initial(false)
+  @property()
+  protected declare readonly playing: Signal<boolean, this>;
+
+  private lastTime = -1;
+
+  public constructor(props: VideoProps) {
+    super(props);
+  }
+
+  @computed()
+  public completion(): number {
+    return this.clampTime(this.time()) / this.video().duration;
+  }
+
+  @computed()
+  protected video(): HTMLVideoElement {
+    const src = this.src();
+    const key = `${this.key}/${src}`;
+    if (Video.pool[key]) {
+      return Video.pool[key];
+    }
+
+    const video = View2D.document.createElement('video');
+    video.src = src;
+    if (video.readyState < 2) {
+      collectPromise(
+        new Promise<void>(resolve => {
+          const listener = () => {
+            resolve();
+            video.removeEventListener('canplay', listener);
+          };
+          video.addEventListener('canplay', listener);
+        }),
+      );
+    }
+    Video.pool[key] = video;
+
+    return video;
+  }
+
+  @computed()
+  protected seekedVideo(): HTMLVideoElement {
+    const video = this.video();
+    const time = this.clampTime(this.time());
+
+    if (!video.paused) {
+      video.pause();
+    }
+
+    if (this.lastTime === time) {
+      return video;
+    }
+
+    this.setCurrentTime(time);
+
+    return video;
+  }
+
+  @computed()
+  protected fastSeekedVideo(): HTMLVideoElement {
+    const video = this.video();
+    const time = this.clampTime(this.time());
+    if (this.lastTime === time) {
+      return video;
+    }
+
+    const playing = this.playing() && time < video.duration;
+    if (playing) {
+      if (video.paused) {
+        collectPromise(video.play());
+      }
+    } else {
+      if (!video.paused) {
+        video.pause();
+      }
+    }
+
+    if (Math.abs(video.currentTime - time) > 0.2) {
+      this.setCurrentTime(time);
+    } else if (!playing) {
+      video.currentTime = time;
+    }
+
+    return video;
+  }
+
+  protected override draw(context: CanvasRenderingContext2D) {
+    this.drawShape(context);
+    if (this.clip()) {
+      context.clip(this.getPath());
+    }
+
+    const alpha = this.alpha();
+    if (alpha > 0) {
+      const video =
+        useProject().playbackState() === PlaybackState.Playing
+          ? this.fastSeekedVideo()
+          : this.seekedVideo();
+
+      const rect = RectType.fromSizeCentered(this.computedSize());
+      context.save();
+      if (alpha < 1) {
+        context.globalAlpha *= alpha;
+      }
+      context.imageSmoothingEnabled = this.smoothing();
+      drawImage(context, video, rect);
+      context.restore();
+    }
+
+    this.drawChildren(context);
+  }
+
+  protected override applyFlex() {
+    super.applyFlex();
+    const video = this.video();
+    this.element.style.aspectRatio = this.parseValue(
+      this.ratio() ?? video.videoWidth / video.videoHeight,
+    );
+  }
+
+  protected setCurrentTime(value: number) {
+    const video = this.video();
+    video.currentTime = value;
+    this.lastTime = value;
+    if (video.seeking) {
+      collectPromise(
+        new Promise<void>(resolve => {
+          const listener = () => {
+            resolve();
+            video.removeEventListener('seeked', listener);
+          };
+          video.addEventListener('seeked', listener);
+        }),
+      );
+    }
+  }
+
+  public play() {
+    const time = useThread().time;
+    const start = time() - this.time();
+    this.playing(true);
+    this.time(() => this.clampTime(time() - start));
+  }
+
+  public pause() {
+    this.playing(false);
+    this.time.save();
+    this.video().pause();
+  }
+
+  public seek(time: number) {
+    const playing = this.playing();
+    this.time(this.clampTime(time));
+    if (playing) {
+      this.play();
+    } else {
+      this.pause();
+    }
+  }
+
+  public clampTime(time: number): number {
+    return clamp(0, this.video().duration, time);
+  }
+
+  protected override collectAsyncResources() {
+    super.collectAsyncResources();
+    this.seekedVideo();
+  }
+}

--- a/packages/2d/src/components/index.ts
+++ b/packages/2d/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Circle';
+export * from './CodeBlock';
 export * from './Image';
 export * from './Layout';
 export * from './Line';
@@ -6,3 +7,4 @@ export * from './Node';
 export * from './Rect';
 export * from './Text';
 export * from './types';
+export * from './Video';

--- a/packages/2d/src/scenes/Scene2D.ts
+++ b/packages/2d/src/scenes/Scene2D.ts
@@ -26,7 +26,7 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
     return this.view;
   }
 
-  public render(context: CanvasRenderingContext2D): void {
+  public draw(context: CanvasRenderingContext2D) {
     context.save();
     this.renderLifecycle.dispatch([SceneRenderEvent.BeforeRender, context]);
     context.save();

--- a/packages/core/src/flow/scheduling.ts
+++ b/packages/core/src/flow/scheduling.ts
@@ -58,13 +58,13 @@ export function* waitFor(
   const thread = useThread();
   const step = project.framesToSeconds(1);
 
-  const targetTime = thread.time + seconds;
+  const targetTime = thread.time() + seconds;
   // subtracting the step is not necessary, but it keeps the thread time ahead
   // of the project time.
   while (targetTime - step > project.time) {
     yield;
   }
-  thread.time = targetTime;
+  thread.time(targetTime);
 
   if (after) {
     yield* after;

--- a/packages/core/src/scenes/Scene.ts
+++ b/packages/core/src/scenes/Scene.ts
@@ -161,9 +161,8 @@ export interface Scene<T = unknown> {
    * Render the scene onto a canvas.
    *
    * @param context - The context to used when rendering.
-   * @param canvas - The canvas onto which the scene should be rendered.
    */
-  render(context: CanvasRenderingContext2D, canvas: HTMLCanvasElement): void;
+  render(context: CanvasRenderingContext2D): Promise<void>;
 
   /**
    * Reload the scene.

--- a/packages/core/src/threading/Thread.ts
+++ b/packages/core/src/threading/Thread.ts
@@ -1,6 +1,6 @@
 import {GeneratorHelper} from '../helpers';
 import {ThreadGenerator} from './ThreadGenerator';
-import {endThread, startThread, useProject} from '../utils';
+import {createSignal, endThread, startThread, useProject} from '../utils';
 
 /**
  * A class representing an individual thread.
@@ -25,7 +25,7 @@ export class Thread {
    * Used by {@link waitFor} and other time-based functions to properly
    * support durations shorter than one frame.
    */
-  public time = 0;
+  public readonly time = createSignal(0);
 
   /**
    * Check if this thread or any of its ancestors has been canceled.
@@ -46,7 +46,7 @@ export class Thread {
   ) {
     const project = useProject();
     this.frameDuration = project.framesToSeconds(1);
-    this.time = project.time;
+    this.time(project.time);
   }
 
   /**
@@ -64,7 +64,7 @@ export class Thread {
    * Prepare the thread for the next update cycle.
    */
   public update() {
-    this.time += useProject().framesToSeconds(1);
+    this.time(this.time() + useProject().framesToSeconds(1));
     this.children = this.children.filter(child => !child.canceled);
   }
 
@@ -72,7 +72,7 @@ export class Thread {
     child.cancel();
     child.parent = this;
     child.isCanceled = false;
-    child.time = this.time;
+    child.time(this.time());
     this.children.push(child);
 
     if (!Object.getPrototypeOf(child.runner).threadable) {

--- a/packages/core/src/threading/ThreadGenerator.ts
+++ b/packages/core/src/threading/ThreadGenerator.ts
@@ -48,5 +48,7 @@ export type ThreadGenerator = Generator<
  * @param value - A possible thread {@link ThreadGenerator}.
  */
 export function isThreadGenerator(value: unknown): value is ThreadGenerator {
-  return typeof value === 'object' && Symbol.iterator in value;
+  return (
+    typeof value === 'object' && Symbol.iterator in value && 'next' in value
+  );
 }

--- a/packages/core/src/threading/cancel.ts
+++ b/packages/core/src/threading/cancel.ts
@@ -21,7 +21,7 @@ export function cancel(...tasks: ThreadGenerator[]) {
     const child = thread.children.find(thread => thread.runner === task);
     if (child && !child.canceled) {
       child.cancel();
-      child.time = thread.time;
+      child.time(thread.time());
     }
   }
 }

--- a/packages/core/src/threading/join.ts
+++ b/packages/core/src/threading/join.ts
@@ -55,20 +55,20 @@ export function* join(
     .map(task => parent.children.find(thread => thread.runner === task))
     .filter(thread => thread);
 
-  const startTime = parent.time;
+  const startTime = parent.time();
   let childTime;
   if (all) {
     while (threads.find(thread => !thread.canceled)) {
       yield;
     }
-    childTime = Math.max(...threads.map(thread => thread.time));
+    childTime = Math.max(...threads.map(thread => thread.time()));
   } else {
     while (!threads.find(thread => thread.canceled)) {
       yield;
     }
     const canceled = threads.filter(thread => thread.canceled);
-    childTime = Math.min(...canceled.map(thread => thread.time));
+    childTime = Math.min(...canceled.map(thread => thread.time()));
   }
 
-  parent.time = Math.max(startTime, childTime);
+  parent.time(Math.max(startTime, childTime));
 }

--- a/packages/core/src/tweening/tween.ts
+++ b/packages/core/src/tweening/tween.ts
@@ -11,8 +11,8 @@ export function* tween(
   const project = useProject();
   const thread = useThread();
 
-  const startTime = thread.time;
-  const endTime = thread.time + seconds;
+  const startTime = thread.time();
+  const endTime = thread.time() + seconds;
 
   onProgress(0, 0);
   while (endTime > project.time) {
@@ -23,7 +23,7 @@ export function* tween(
     }
     yield;
   }
-  thread.time = endTime;
+  thread.time(endTime);
 
   onProgress(1, seconds);
   onEnd?.(1, seconds);

--- a/packages/core/src/utils/createComputedAsync.test.ts
+++ b/packages/core/src/utils/createComputedAsync.test.ts
@@ -1,0 +1,19 @@
+import {createSignal} from './createSignal';
+import {createComputedAsync} from './createComputedAsync';
+
+function sleep(duration = 0) {
+  return new Promise(resolve => setTimeout(resolve, duration));
+}
+
+describe('createComputedAsync()', () => {
+  test('Value is updated when the promise resolves', async () => {
+    const computed = createComputedAsync(() => sleep().then(() => true), false);
+    const signal = createSignal(() => computed());
+
+    expect(signal()).toBe(false);
+
+    await sleep(1);
+
+    expect(signal()).toBe(true);
+  });
+});

--- a/packages/core/src/utils/createComputedAsync.ts
+++ b/packages/core/src/utils/createComputedAsync.ts
@@ -1,0 +1,10 @@
+import {Computed, createComputed} from './createComputed';
+import {collectPromise} from './createSignal';
+
+export function createComputedAsync<T>(
+  factory: () => Promise<T>,
+  initial: T = null,
+): Computed<T> {
+  const handle = createComputed(() => collectPromise(factory(), initial));
+  return createComputed(() => handle().value);
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './createComputed';
+export * from './createComputedAsync';
 export * from './createSignal';
 export * from './range';
 export * from './useAnimator';

--- a/packages/core/src/utils/useTime.ts
+++ b/packages/core/src/utils/useTime.ts
@@ -18,5 +18,5 @@ import {useThread} from './useThread';
  * ```
  */
 export function useTime() {
-  return useThread().time;
+  return useThread().time();
 }

--- a/packages/ui/src/hooks/usePlayerState.ts
+++ b/packages/ui/src/hooks/usePlayerState.ts
@@ -1,8 +1,6 @@
 import {usePlayer} from '../contexts';
 import {useSubscribableValue} from './useSubscribable';
 
-// TODO Save and restore the player state.
-
 export function usePlayerState() {
   const player = usePlayer();
   return useSubscribableValue(player.onStateChanged);


### PR DESCRIPTION
- Added a `Video` node.
- `Thread.time` is now a signal.
- `createComputedAsync` is a new special signal that updates when a promise resolves.
- `GeneratorScene` now automatically awaits any async resources required when rendering.