### PR TITLE
feat: open time events in editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17886,7 +17886,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20337,6 +20338,7 @@
         "@motion-canvas/core": "^12.0.0-alpha.2",
         "@preact/preset-vite": "^2.3.0",
         "preact": "10.7.3",
+        "source-map-js": "^1.0.2",
         "typescript": "^4.6.4",
         "vite": "^3.0.4"
       },
@@ -23432,7 +23434,7 @@
     "@motion-canvas/core": {
       "version": "file:packages/core",
       "requires": {
-        "@types/chroma-js": "*",
+        "@types/chroma-js": "^2.1.4",
         "@types/dom-webcodecs": "^0.1.4",
         "@types/jest": "^28.1.4",
         "canvas-5-polyfill": "^0.1.5",
@@ -23491,6 +23493,7 @@
         "@motion-canvas/core": "^12.0.0-alpha.2",
         "@preact/preset-vite": "^2.3.0",
         "preact": "10.7.3",
+        "source-map-js": "*",
         "typescript": "^4.6.4",
         "vite": "^3.0.4"
       },
@@ -31849,7 +31852,9 @@
       }
     },
     "source-map-js": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-support": {
       "version": "0.5.13",

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -201,8 +201,9 @@ export abstract class GeneratorScene<T>
     const promises = consumePromises();
     if (promises.length > 0) {
       await Promise.all(promises.map(handle => handle.promise));
-      // TODO Display a more helpful message
-      console.error(promises);
+      console.error(
+        'Tried to access an asynchronous property before the node was ready.',
+      );
     }
 
     if (result.done) {

--- a/packages/core/src/scenes/TimeEvents.ts
+++ b/packages/core/src/scenes/TimeEvents.ts
@@ -27,6 +27,10 @@ export interface TimeEvent {
    * Duration of the event in seconds.
    */
   offset: number;
+  /**
+   * Stack trace at the moment of registration.
+   */
+  stack?: string;
 }
 
 /**
@@ -115,10 +119,14 @@ export class TimeEvents {
         initialTime,
         targetTime: initialTime,
         offset: 0,
+        stack: new Error().stack,
       };
     } else {
       let changed = false;
-      const event = {...this.lookup[name]};
+      const event = {
+        ...this.lookup[name],
+        stack: new Error().stack,
+      };
       if (event.initialTime !== initialTime) {
         event.initialTime = initialTime;
         changed = true;

--- a/packages/core/src/utils/createComputed.ts
+++ b/packages/core/src/utils/createComputed.ts
@@ -1,5 +1,10 @@
 import {FlagDispatcher, Subscribable} from '../events';
-import {collect, finishCollecting, startCollecting} from './createSignal';
+import {
+  collect,
+  DependencyContext,
+  finishCollecting,
+  startCollecting,
+} from './createSignal';
 
 export type Computed<TValue> = (...args: any[]) => TValue;
 
@@ -7,27 +12,27 @@ export function createComputed<TValue>(
   factory: Computed<TValue>,
 ): Computed<TValue> {
   let last: TValue;
-  const dependencies = new Set<Subscribable<void>>();
   const event = new FlagDispatcher();
-
-  function markDirty() {
-    event.raise();
-  }
+  const context: DependencyContext = {
+    dependencies: new Set<Subscribable<void>>(),
+    handler: () => event.raise(),
+  };
 
   const handler = <Computed<TValue>>function handler(...args: any[]) {
     if (event.isRaised()) {
-      dependencies.forEach(dep => dep.unsubscribe(markDirty));
-      dependencies.clear();
-      startCollecting([dependencies, markDirty]);
+      context.dependencies.forEach(dep => dep.unsubscribe(context.handler));
+      context.dependencies.clear();
+      context.stack = new Error().stack;
+      startCollecting(context);
       last = factory(...args);
-      finishCollecting([dependencies, markDirty]);
+      finishCollecting(context);
     }
     event.reset();
     collect(event.subscribable);
     return last;
   };
 
-  markDirty();
+  context.handler();
 
   return handler;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
     "@motion-canvas/core": "^12.0.0-alpha.2",
     "@preact/preset-vite": "^2.3.0",
     "preact": "10.7.3",
+    "source-map-js": "^1.0.2",
     "typescript": "^4.6.4",
     "vite": "^3.0.4"
   }

--- a/packages/ui/src/components/timeline/Label.tsx
+++ b/packages/ui/src/components/timeline/Label.tsx
@@ -4,6 +4,7 @@ import type {Scene, TimeEvent} from '@motion-canvas/core/lib/scenes';
 import {useDrag} from '../../hooks';
 import {useCallback, useLayoutEffect, useState} from 'preact/hooks';
 import {usePlayer, useProject, useTimelineContext} from '../../contexts';
+import {findAndOpenFirstUserFile} from '../../utils';
 
 interface LabelProps {
   event: TimeEvent;
@@ -40,6 +41,11 @@ export function Label({event, scene}: LabelProps) {
   return (
     <>
       <div
+        onDblClick={async () => {
+          if (event.stack) {
+            await findAndOpenFirstUserFile(event.stack);
+          }
+        }}
         onMouseDown={e => {
           if (e.button === 1) {
             e.preventDefault();

--- a/packages/ui/src/utils/SourceMapUtils.ts
+++ b/packages/ui/src/utils/SourceMapUtils.ts
@@ -1,0 +1,79 @@
+import {MappedPosition, SourceMapConsumer} from 'source-map-js';
+
+export interface FileInfo {
+  position: MappedPosition;
+  sourceMap: SourceMapConsumer;
+}
+
+const sourceMaps: Record<string, SourceMapConsumer> = {};
+const externalFileRegex = /^\/(@fs|node_modules)\//;
+const stackTraceRegex = navigator.userAgent.toLowerCase().includes('chrome')
+  ? /^ +at.+\((.*):([0-9]+):([0-9]+)/
+  : /@(.*):([0-9]+):([0-9]+)/;
+
+async function getSourceMap(file: string): Promise<SourceMapConsumer> {
+  if (file in sourceMaps) {
+    return sourceMaps[file];
+  }
+
+  const response = await fetch(`${file}.map`);
+  const sourceMap = new SourceMapConsumer(await response.json());
+  sourceMaps[file] = sourceMap;
+
+  return sourceMap;
+}
+
+export async function findFirstUserFile(
+  stack: string,
+): Promise<FileInfo | null> {
+  const lines = stack.split('\n');
+  while (lines.length > 0) {
+    const match = lines.pop().match(stackTraceRegex);
+    if (!match) continue;
+    const [, uri, line, column] = match;
+    const file = new URL(uri).pathname;
+    if (!externalFileRegex.test(file)) {
+      try {
+        const sourceMap = await getSourceMap(file);
+        const position = sourceMap.originalPositionFor({
+          line: parseInt(line),
+          column: parseInt(column),
+        });
+        return {sourceMap, position};
+      } catch (e) {
+        // do nothing
+      }
+    }
+  }
+
+  return null;
+}
+
+export async function openFileInEditor(position: MappedPosition) {
+  const relative = position.source.startsWith('/')
+    ? position.source.slice(1)
+    : position.source;
+  await fetch(
+    `/__open-in-editor?file=${encodeURIComponent(relative)}:${position.line}:${
+      position.column
+    }`,
+  );
+}
+
+export function getSourceCodeFrame(info: FileInfo): string {
+  const source = info.sourceMap.sourceContentFor(info.position.source);
+  const sourceLines = source.split('\n');
+  const {line, column} = info.position;
+  const formated = sourceLines
+    .slice(line - 1, line + 2)
+    .map((text, index) => `${line + index} | ${text}`);
+  formated.splice(1, 0, `   | ${' '.repeat(column)}^`);
+  return formated.join('\n');
+}
+
+export async function findAndOpenFirstUserFile(stack: string) {
+  const fileInfo = await findFirstUserFile(stack);
+  if (fileInfo) {
+    await openFileInEditor(fileInfo.position);
+  }
+}

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './classes';
+export * from './SourceMapUtils';


### PR DESCRIPTION
- double-clicking a time event opens its location in the IDE.
- signals keep track of their stack trace for better error logging in the future.