### PR TITLE
feat(2d): unify desired sizes

### DIFF
--- a/packages/2d/src/components/Image.ts
+++ b/packages/2d/src/components/Image.ts
@@ -4,9 +4,15 @@ import {
   SignalValue,
 } from '@motion-canvas/core/lib/utils';
 import {computed, initial, property} from '../decorators';
-import {Color, Rect as RectType, Vector2} from '@motion-canvas/core/lib/types';
+import {
+  Color,
+  Rect as RectType,
+  SerializedVector2,
+  Vector2,
+} from '@motion-canvas/core/lib/types';
 import {drawImage} from '../utils';
 import {Rect, RectProps} from './Rect';
+import {Length} from '../partials';
 
 export interface ImageProps extends RectProps {
   src?: SignalValue<string>;
@@ -30,6 +36,19 @@ export class Image extends Rect {
 
   public constructor(props: ImageProps) {
     super(props);
+  }
+
+  protected override desiredSize(): SerializedVector2<Length> {
+    const custom = super.desiredSize();
+    if (custom.x === null && custom.y === null) {
+      const image = this.image();
+      return {
+        x: image.naturalWidth,
+        y: image.naturalHeight,
+      };
+    }
+
+    return custom;
   }
 
   @computed()

--- a/packages/2d/src/components/Layout.ts
+++ b/packages/2d/src/components/Layout.ts
@@ -217,7 +217,7 @@ export class Layout extends Node {
     timingFunction: TimingFunction,
     interpolationFunction: InterpolationFunction<Length>,
   ): ThreadGenerator {
-    const width = this.customWidth();
+    const width = this.desiredSize().x;
     const lock = typeof width !== 'number' || typeof value !== 'number';
     let from: number;
     if (lock) {
@@ -257,7 +257,7 @@ export class Layout extends Node {
     timingFunction: TimingFunction,
     interpolationFunction: InterpolationFunction<Length>,
   ): ThreadGenerator {
-    const height = this.customHeight();
+    const height = this.desiredSize().y;
     const lock = typeof height !== 'number' || typeof value !== 'number';
 
     let from: number;
@@ -297,7 +297,7 @@ export class Layout extends Node {
   @property()
   protected declare readonly customHeight: Signal<Length, this>;
   @computed()
-  protected customSize(): SerializedVector2<Length> {
+  protected desiredSize(): SerializedVector2<Length> {
     return {
       x: this.customWidth(),
       y: this.customHeight(),
@@ -311,7 +311,7 @@ export class Layout extends Node {
     timingFunction: TimingFunction,
     interpolationFunction: InterpolationFunction<Vector2>,
   ): ThreadGenerator {
-    const size = this.customSize();
+    const size = this.desiredSize();
     let from: Vector2;
     if (typeof size.x !== 'number' || typeof size.y !== 'number') {
       from = this.size();
@@ -633,8 +633,9 @@ export class Layout extends Node {
   protected applyFlex() {
     this.element.style.position = this.isLayoutRoot() ? 'absolute' : 'relative';
 
-    this.element.style.width = this.parseLength(this.customWidth());
-    this.element.style.height = this.parseLength(this.customHeight());
+    const size = this.desiredSize();
+    this.element.style.width = this.parseLength(size.x);
+    this.element.style.height = this.parseLength(size.y);
     this.element.style.maxWidth = this.parseLength(this.maxWidth());
     this.element.style.minWidth = this.parseLength(this.minWidth());
     this.element.style.maxHeight = this.parseLength(this.maxHeight());

--- a/packages/2d/src/components/Line.ts
+++ b/packages/2d/src/components/Line.ts
@@ -3,7 +3,7 @@ import {Node} from './Node';
 import {computed, initial, property} from '../decorators';
 import {arc, lineTo, moveTo, resolveCanvasStyle} from '../utils';
 import {Signal, SignalValue} from '@motion-canvas/core/lib/utils';
-import {Rect, Vector2} from '@motion-canvas/core/lib/types';
+import {Rect, SerializedVector2, Vector2} from '@motion-canvas/core/lib/types';
 import {clamp} from '@motion-canvas/core/lib/tweening';
 import {Length} from '../partials';
 import {Layout} from './Layout';
@@ -65,18 +65,8 @@ export class Line extends Shape {
   @property()
   public declare readonly arrowSize: Signal<number, this>;
 
-  public getCustomWidth(): Length {
-    return this.childrenRect().width;
-  }
-  public setCustomWidth() {
-    // do nothing
-  }
-
-  public getCustomHeight(): Length {
-    return this.childrenRect().height;
-  }
-  public setCustomHeight() {
-    // do nothing
+  protected override desiredSize(): SerializedVector2<Length> {
+    return this.childrenRect().size;
   }
 
   public constructor(props: LineProps) {

--- a/packages/2d/src/components/Video.ts
+++ b/packages/2d/src/components/Video.ts
@@ -1,4 +1,7 @@
-import {Rect as RectType} from '@motion-canvas/core/lib/types';
+import {
+  Rect as RectType,
+  SerializedVector2,
+} from '@motion-canvas/core/lib/types';
 import {drawImage} from '../utils';
 import {computed, initial, property} from '../decorators';
 import {
@@ -11,6 +14,7 @@ import {
 import {PlaybackState} from '@motion-canvas/core';
 import {clamp} from '@motion-canvas/core/lib/tweening';
 import {Rect, RectProps} from './Rect';
+import {Length} from '../partials';
 
 export interface VideoProps extends RectProps {
   src?: SignalValue<string>;
@@ -46,6 +50,19 @@ export class Video extends Rect {
 
   public constructor(props: VideoProps) {
     super(props);
+  }
+
+  protected override desiredSize(): SerializedVector2<Length> {
+    const custom = super.desiredSize();
+    if (custom.x === null && custom.y === null) {
+      const image = this.video();
+      return {
+        x: image.videoWidth,
+        y: image.videoHeight,
+      };
+    }
+
+    return custom;
   }
 
   @computed()


### PR DESCRIPTION
All nodes whose sizes are governed by custom rules (`Image`, `Video`, etc) now use a unified `desiredSize()` method to specify said rules.