### PR TITLE
docs: fix spelling of interpolation

### DIFF
--- a/packages/docs/docs/getting-started/tweening.mdx
+++ b/packages/docs/docs/getting-started/tweening.mdx
@@ -77,7 +77,7 @@ map(-300, 300, easeInOutCubic(value));
 easeInOutCubic(value, -300, 300);
 ```
 
-## Interplation functions
+## Interpolation functions
 
 So far, we've only animated a single, numeric value.
 The [`map`](/api/core/tweening#map) function can be used to interpolate between


### PR DESCRIPTION
I assume the last line is a missing newline, I used the github text editor.