### PR TITLE
fix(docs): fix typo in configuration.mdx

### DIFF
--- a/packages/docs/docs/getting-started/configuration.mdx
+++ b/packages/docs/docs/getting-started/configuration.mdx
@@ -69,7 +69,7 @@ Stills are saved to a `still` subdirectory:
 
 Defines which assets should be buffered before being sent to the browser.
 
-Streaming larger assets directly from the drive my cause issues with other
+Streaming larger assets directly from the drive may cause issues with other
 applications. For instance, if an audio file is being used in the project, Adobe
 Audition will perceive it as "being used by another application" and refuse to
 override it.


### PR DESCRIPTION
"my" -> "may"