### PR TITLE
Fix two typos in getting-started/references.mdx

### DIFF
--- a/packages/docs/docs/getting-started/references.mdx
+++ b/packages/docs/docs/getting-started/references.mdx
@@ -59,8 +59,8 @@ If you find the latter example more readable, this guide is for you.
 ## `ref` property
 
 Each node in Motion Canvas has a property called `ref` that allows you to create
-a reference to said node. It excepts a callback that will be invoked right after
-the node has benn created, with the first argument being the newly created
+a reference to said node. It accepts a callback that will be invoked right after
+the node has been created, with the first argument being the newly created
 instance.
 
 With this in mind, we can rewrite the initial example as:


### PR DESCRIPTION
Just two typos I noticed while reading the (excellent) getting started guide.