### PR TITLE
[Documentation] Info panel for Firefox Users

### DIFF
--- a/packages/docs/docs/getting-started/hierarchy.mdx
+++ b/packages/docs/docs/getting-started/hierarchy.mdx
@@ -6,6 +6,7 @@ slug: /hierarchy
 import Mermaid from '@theme/Mermaid';
 import CodeBlock from '@theme/CodeBlock';
 import ApiSnippet from '@site/src/components/Api/ApiSnippet';
+import FirefoxTextWarning from '@site/src/warnings/FirefoxTextWarning';
 
 # Scene hierarchy
 
@@ -15,6 +16,8 @@ the Document Object Model used ot represent HTML and XML documents.
 
 Here's an example of a simple scene hierarchy together with its object
 representation:
+
+<FirefoxTextWarning />
 
 <div className="row margin-bottom--md">
   <div className="col col--6">

--- a/packages/docs/docs/getting-started/references.mdx
+++ b/packages/docs/docs/getting-started/references.mdx
@@ -3,6 +3,8 @@ sidebar_position: 7
 slug: /references
 ---
 
+import FirefoxTextWarning from '@site/src/warnings/FirefoxTextWarning';
+
 # References
 
 Usually, when creating a node, we want to store a reference to it, so we can
@@ -100,9 +102,8 @@ yield * circle().scale(2, 0.3);
 ```
 
 Notice that `circle` is no longer just a variable that points to our circle.
-Instead, it's a [signal-like](/docs/signals) function that can
-be used to access it. Invoking it without any arguments (`circle()`) returns our
-instance.
+Instead, it's a [signal-like](/docs/signals) function that can be used to access
+it. Invoking it without any arguments (`circle()`) returns our instance.
 
 Going back to the example with the more complex scene, we can now rewrite it as:
 
@@ -178,6 +179,8 @@ that we can use to animate all of them.
 
 ### Custom functions
 
+<FirefoxTextWarning />
+
 `makeRef()` can also be used to return more than one reference from a custom
 function component:
 
@@ -212,6 +215,8 @@ property to pass the `label` object created by us. `makeRef()` is then used to
 fill this object with all the necessary references.
 
 ## `makeRefs()` function
+
+<FirefoxTextWarning />
 
 Looking at the previous example, you may notice that we had to define the `refs`
 type twice. First in the `Label` declaration and then again when creating the

--- a/packages/docs/docs/getting-started/signals.mdx
+++ b/packages/docs/docs/getting-started/signals.mdx
@@ -6,6 +6,7 @@ slug: /signals
 import AnimationPlayer from '@site/src/components/AnimationPlayer';
 import CodeBlock from '@theme/CodeBlock';
 import signalSource from '!!raw-loader!@motion-canvas/examples/src/scenes/node-signal';
+import FirefoxTextWarning from '@site/src/warnings/FirefoxTextWarning';
 
 # Signals
 
@@ -109,6 +110,8 @@ We can use the fact that properties of nodes are represented by signals to const
 <AnimationPlayer small name="node-signal" />
 
 Below you'll find the code used to create this animation. We highlighted all the places where signals are used:
+
+<FirefoxTextWarning />
 
 <CodeBlock language="tsx">{signalSource}</CodeBlock>
 

--- a/packages/docs/src/warnings/FirefoxTextWarning.tsx
+++ b/packages/docs/src/warnings/FirefoxTextWarning.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Admonition from '@site/src/theme/Admonition';
+import Link from '@docusaurus/Link';
+
+export default function FirefoxTextWarning() {
+  return (
+    <Admonition type="caution">
+      If you are using Firefox make sure to check if{' '}
+      <code>dom.textMetrics.fontBoundingBox</code> is enabled else you might not
+      see the{' '}
+      <Link to="/api/2d/components/Text">
+        <code>Text</code>
+      </Link>
+      . You can enable this by navigating to <code>about:config</code>.
+    </Admonition>
+  );
+}


### PR DESCRIPTION
Since there currently is some confusion for Firefox users, why the `Text` component is not rendered / visible an Info Panel could help aid with confusion.

I put them everywhere where the `Text` component has been used in the docs, since it made the most sense to me.

Related Issue: #179