### PR TITLE
docs: clarification on scaffolding process

### DIFF
--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -34,6 +34,13 @@ Run the following command in order to scaffold a new Motion Canvas project:
 npm init @motion-canvas
 ```
 
+:::tip
+
+Unless you plan to contribute, you do not need to clone the github repo. 
+As long as you have node, this command is all you need.
+
+:::
+
 Answer the prompts to name your project and select which language you would like
 to use; either TypeScript or plain JavaScript.
 


### PR DESCRIPTION
Clarifies that to use Motion Canvas, cloning the repo is not required.

Issue #196 