### PR TITLE
docs: fix typo in quickstart.mdx

### DIFF
--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -122,7 +122,7 @@ scene.
 You can learn more about scenes, nodes, and this XML-like syntax in the
 [scene hierarchy](/docs/hierarchy) section. For now, what's important is that,
 in our example, we add an individual [`<Circle/>`](/api/2d/components/Circle)
-node to our scene. We make it red, set its width and height as `320` pixels and
+node to our scene. We make it red, set its width and height as `240` pixels and
 position it `300` pixels left from the center:
 
 ```tsx


### PR DESCRIPTION
- Fixed typo in value assigned to **width** and **height** in [quickstart.mdx](/motion-canvas/motion-canvas/blob/main/packages/docs/docs/getting-started/quickstart.mdx)
- Resolves: #186

### Previously:
![image](https://user-images.githubusercontent.com/94586121/216842376-9da22063-7b23-49dd-8341-f3a9e717f68f.png)

### Fixed:
![image](https://user-images.githubusercontent.com/94586121/216842006-51d94f56-9dcc-44f5-963f-3a6bbb1ba1fd.png)
