### PR TITLE
docs: add warning for Vite not watching files in WSL2

### DIFF
--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -81,8 +81,8 @@ reflected in the preview.
 
 When running Vite on WSL2, file system watching does not work if a file is edited by Windows applications.
 
-For Vite to properly reload changed files, move the project folder into the WSL2 file system and use WSL2 applications to edit files. 
-Accessing the Windows filesytem from WSL2 is slow, so this will improve performance.
+To fix this, move the project folder into the WSL2 file system and use WSL2 applications to edit files.  
+Accessing the Windows file system from WSL2 is slow, so this will improve performance.
 
 For more information view the [**Vite Docs**](https://vitejs.dev/config/server-options.html#server-watch).
 

--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -75,7 +75,20 @@ file with the following snippet.
 </CodeBlock>
 
 Now save the file. Any changes you make are automatically picked up and
-reflected in the preview. You should see a gray circle in the preview pane at
+reflected in the preview. 
+
+:::caution Vite on Windows Subsystem for Linux (WSL) 2
+
+When running Vite on WSL2, file system watching does not work if a file is edited by Windows applications.
+
+For Vite to properly reload changed files, move the project folder into the WSL2 file system and use WSL2 applications to edit files. 
+Accessing the Windows filesytem from WSL2 is slow, so this will improve performance.
+
+For more information view the [**Vite Docs**](https://vitejs.dev/config/server-options.html#server-watch).
+
+:::
+
+You should see a gray circle in the preview pane at
 the top right of the web application. Press the play button to see the circle
 animate across the screen.
 


### PR DESCRIPTION
- Add Caution Admonition (from Docusaurus) on quickstart page in docs in order to alert developers using WSL2 of its inability to alert Vite to file changes unless updated by WSL2 applications.
- Resolves: #214

![image](https://user-images.githubusercontent.com/94586121/217067331-1edacff8-8009-4ba3-84d0-23fedfcc9d4f.png)
