### PR TITLE
feat: add `useDuration` helper

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,3 +17,4 @@ export * from './useScene';
 export * from './useThread';
 export * from './useTime';
 export * from './useContext';
+export * from './useDuration';

--- a/packages/core/src/utils/useDuration.ts
+++ b/packages/core/src/utils/useDuration.ts
@@ -1,0 +1,31 @@
+import {useScene} from './useScene';
+
+/**
+ * Register a time event and get its duration in seconds.
+ *
+ * @remarks
+ * This can be used to better specify when an animation should start
+ * as well as how long this animation should take
+ *
+ * @example
+ * ```ts
+ * export default makeScene2D(function* (view) {
+ *   const circle = createRef<Circle>();
+ *
+ *   view.add(
+ *     <Circle ref={circle} width={320} height={320} fill={'lightseagreen'} />,
+ *   );
+ *
+ *   yield* circle().scale(2, useDuration('circleGrow'));
+ * });
+ * ```
+ *
+ * @param name - The name of the event.
+ *
+ * @returns The duration of the event in seconds.
+ */
+export function useDuration(name: string): number {
+  const scene = useScene();
+  scene.timeEvents.register(name);
+  return scene.timeEvents.get(name).offset;
+}

--- a/packages/docs/docs/getting-started/time-events.mdx
+++ b/packages/docs/docs/getting-started/time-events.mdx
@@ -48,3 +48,14 @@ it. This is useful when you want to extend or shorten a pause in your voiceover
 because correcting the first time event after the pause will also fix all events
 after it. You can hold `SHIFT` when editing an event to prevent this from
 happening.
+
+## Controlling animation duration
+
+Aside from specifying _when_ something should happen, Time Events can also be used to 
+control _how long_ something should last. You can use the 
+[`useDuration`](/api/core/utils#useDuration) function to retrieve the duration of an event
+and use it in your animation:
+
+```ts
+yield* circle().scale(2, useDuration('event'));
+```


### PR DESCRIPTION
## What has changed?

This Pull Request adds a new helper / utility function that allows for easier creation and usage of `TimeEvent`s for animations.

Furthermore, the documentation has been extended and now features a subsection ("Controlling animation duration with Time Events") under the `Time Events` chapter.

Closes: #171

---

## Example
Let's look at the following example where we want to animate the `scale` of a `circle`:
```tsx
import {makeScene2D} from '@motion-canvas/2d';
import {Circle} from '@motion-canvas/2d/lib/components';
import {createRef, useScene} from '@motion-canvas/core/lib/utils';

export default makeScene2D(function* (view) {
  const circle = createRef<Circle>();

  view.add(
    <Circle ref={circle} width={320} height={320} fill={'lightseagreen'} />,
  );

  useScene().timeEvents.register('event');
  const duration = useScene().timeEvents.get('event').offset;
  yield* circle().scale(2, duration);
});
```

In the example a `TimeEvent` called `event` is registered and its duration gets used to control
the `duration` of the circle's `scale` animation.

With the new `useDuration` function, this can be reduced to a single line of code as follows:
```tsx
yield* circle().scale(2, useDuration('event'));
```
