### PR TITLE
fix(2d): fix Line cache

### DIFF
--- a/packages/2d/src/components/Line.ts
+++ b/packages/2d/src/components/Line.ts
@@ -229,7 +229,7 @@ export class Line extends Shape {
     const rect = this.childrenRect();
     const arrowSize = this.arrowSize();
     const lineWidth = this.lineWidth();
-    return rect.expand(Math.max(0, arrowSize - lineWidth / 2));
+    return rect.expand(Math.max(0, arrowSize, lineWidth / 2));
   }
 
   protected override drawShape(context: CanvasRenderingContext2D) {


### PR DESCRIPTION
Lines with bigger widths no longer get clipped when the node is cached.

Closes: #205