### PR TITLE
feat(2d): add video component property getter

### DIFF
--- a/packages/2d/src/components/Video.ts
+++ b/packages/2d/src/components/Video.ts
@@ -51,6 +51,18 @@ export class Video extends Rect {
     super(props);
   }
 
+  public isPlaying(): boolean {
+    return this.playing();
+  }
+
+  public getCurrentTime(): number {
+    return this.time();
+  }
+
+  public getDuration(): number {
+    return this.video().duration;
+  }
+
   protected override desiredSize(): SerializedVector2<Length> {
     const custom = super.desiredSize();
     if (custom.x === null && custom.y === null) {


### PR DESCRIPTION
## What has been changed in this Pull Request

Getter functions (`isPlaying`, `getCurrentTime` and `getDuration`) were added to provide access to these properties, which is needed in some cases.

Before there was a 'hacky' way of accessing them via the
`indexing operator` (`[]`).

```ts
videoRef()['playing']()
```

With these changes, these property values can be retrieved in a cleaner and secure way without interfering with core logic.

```ts
videoRef().isPlaying()
```

---

Resolves: https://github.com/motion-canvas/motion-canvas/issues/239