### PR TITLE
fix(packaging): change ui:dev script to ui:serve based on README

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "2d:build": "npm run build -w packages/2d",
     "2d:watch": "npm run watch -w packages/2d",
     "ui:build": "npm run build -w packages/ui",
-    "ui:dev": "npm run dev -w packages/ui",
+    "ui:serve": "npm run dev -w packages/ui",
     "ui:showcase": "npm run showcase -w packages/ui",
     "template:serve": "npm run serve -w packages/template",
     "template:build": "npm run build -w packages/template",


### PR DESCRIPTION
Review request: @aarthificial 

Not sure if it was better to change the README.md or the package.json but I went with package.json for consistency with the other scripts. 

Quoting from the README: 

```md
If you want to develop the UI, first build the template project by running: template:build. Next, start ui:serve. ⬅️ This was ui:dev in the package.json
```