### PR TITLE
 make color import clear

### DIFF
--- a/packages/docs/docs/getting-started/tweening.mdx
+++ b/packages/docs/docs/getting-started/tweening.mdx
@@ -85,6 +85,7 @@ two numbers but to animate more complex types we'll need to use interpolation
 functions. Consider the following example:
 
 ```ts
+// import { Color } from "@motion-canvas/core/lib/types";
 yield* tween(2, value => {
   circle().color(
     Color.lerp(


### PR DESCRIPTION
`Color` was introduced here but there's no mention of how to import it, I had to go hunting. I'd suggest putting the import in the example as a comment at the top as I've done here -- this is a style I've seen in many other tutorials/docs.