### PR TITLE
Update tweening.mdx

### DIFF
--- a/packages/docs/docs/getting-started/tweening.mdx
+++ b/packages/docs/docs/getting-started/tweening.mdx
@@ -86,7 +86,7 @@ functions. Consider the following example:
 
 ```ts
 yield* tween(2, value => {
-  circle().color(
+  circle().fill(
     Color.lerp(
       new Color('#e6a700'),
       new Color('#e13238'),


### PR DESCRIPTION
There is no function `color` on `Circle`. Changing it to fill here does the right thing and is in line with the other examples using Circle.