### PR TITLE
docs: fix typescript error in example

### DIFF
--- a/packages/docs/docs/getting-started/flow.mdx
+++ b/packages/docs/docs/getting-started/flow.mdx
@@ -69,7 +69,7 @@ export default makeScene2D(function* (view) {
   yield* flicker(circle());
 });
 
-function* flicker(circle: Circle) {
+function* flicker(circle: Circle): Generator {
   circle.fill('red');
   yield;
   circle.fill('blue');


### PR DESCRIPTION
The `flicker` function in the `Animation Flow` chapter of the docs will produce a typescript error with the project's provided `tsconfig.json`.

```
'flicker', which lacks return-type annotation, implicitly has an 'any' yield type.ts(7055)
``` 

While this doesn't stop the example from working in the player, it can lead to confusion for people who are new to Typescript. I've decided to add `Generator` as the return type hint to keep the example simple (no imports required) while still being more correct than `any`.