### PR TITLE
fix(2d): call spawnChildren() in constructor to initialize spawner parents

### DIFF
--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -33,12 +33,10 @@ import {Filter} from '../partials';
 import {filtersSignal, FiltersSignal} from '../decorators/filtersSignal';
 import {
   createSignal,
-  Signal,
   DependencyContext,
   SignalValue,
   SimpleSignal,
   isReactive,
-  Computed,
 } from '@motion-canvas/core/lib/signals';
 
 export interface NodeProps {
@@ -393,6 +391,7 @@ export class Node implements Promisable<Node> {
     this.add(children);
     if (spawner) {
       this.children(spawner);
+      this.spawnChildren();
     }
   }
 

--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -33,10 +33,12 @@ import {Filter} from '../partials';
 import {filtersSignal, FiltersSignal} from '../decorators/filtersSignal';
 import {
   createSignal,
+  Signal,
   DependencyContext,
   SignalValue,
   SimpleSignal,
   isReactive,
+  Computed,
 } from '@motion-canvas/core/lib/signals';
 
 export interface NodeProps {
@@ -391,7 +393,6 @@ export class Node implements Promisable<Node> {
     this.add(children);
     if (spawner) {
       this.children(spawner);
-      this.spawnChildren();
     }
   }
 

--- a/packages/docs/docs/advanced/spawners.mdx
+++ b/packages/docs/docs/advanced/spawners.mdx
@@ -77,4 +77,8 @@ yield* all(...spawnedCircles.map(function* (circle) {
 }));
 ```
 
+Be aware that the references returned by a call to `children()` may be invalidated
+when the number of spawned objects changes, and accessing the invalidated objects 
+may cause undefined behavior. Try not to save references to spawned objects for too long,
+and use `children()` wherever possible to get the updated list of spawned objects.
 

--- a/packages/docs/docs/advanced/spawners.mdx
+++ b/packages/docs/docs/advanced/spawners.mdx
@@ -62,5 +62,19 @@ const pool = range(64).map(i => (
   <Circle x={i * 32} width={32} height={32} fill={'lightseagreen'} />
 ));
 
-view.add(<Layout layout spawner={() => pool.slice(0, count())} />);
+const layout = createRef<Layout>();
+view.add(<Layout layout ref={layout} spawner={() => pool.slice(0, count())} />);
 ```
+
+Apart from the spawner function, the pool should never be accessed directly.
+Use the `children()` signal of the parent object to get references to the spawned objects:
+
+```tsx
+// ... continuing from above ...
+let spawnedCircles = layout().children() as Circle[];
+yield* all(...spawnedCircles.map(function* (circle) {
+  yield* circle.scale(1.5, 1).to(1, 1);
+}));
+```
+
+


### PR DESCRIPTION
Fixes #270 by calling the spawner function once during construction, to initialize the parents of the spawner objects. A warning in the docs about making sure to null check the parent of spawners would be prudent as well.