### PR TITLE
fix(ui): remove glossy <select> effect in Safari

### DIFF
--- a/packages/ui/src/components/controls/Controls.module.scss
+++ b/packages/ui/src/components/controls/Controls.module.scss
@@ -51,7 +51,7 @@
 .select,
 .input,
 .button {
-  background: var(--surface-color-light);
+  background-color: var(--surface-color-light);
   color: rgba(255, 255, 255, 0.6);
   border: 0;
   border-radius: 4px;
@@ -94,7 +94,7 @@
     font-size: 0;
     flex-grow: 0;
     flex-basis: 0;
-    padding-left: 12px;
+    padding-left: 16px;
     border-radius: 0 4px 4px 0;
   }
 }

--- a/packages/ui/src/components/playback/Playback.module.scss
+++ b/packages/ui/src/components/playback/Playback.module.scss
@@ -8,6 +8,12 @@
   background-color: var(--theme);
 }
 
+.select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 .controls {
   display: flex;
   justify-content: center;

--- a/packages/ui/src/components/playback/Playback.module.scss
+++ b/packages/ui/src/components/playback/Playback.module.scss
@@ -17,4 +17,9 @@
     opacity: 0.54;
     pointer-events: none;
   }
+
+  select,
+  input {
+    width: 70px;
+  }
 }

--- a/packages/ui/src/components/playback/Playback.module.scss
+++ b/packages/ui/src/components/playback/Playback.module.scss
@@ -8,12 +8,6 @@
   background-color: var(--theme);
 }
 
-.select {
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-}
-
 .controls {
   display: flex;
   justify-content: center;

--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -62,7 +62,6 @@ export function PlaybackControls() {
   return (
     <div className={clsx(styles.controls, state.render && styles.disabled)}>
       <Select
-        className={clsx(styles.select)}
         title="Playback speed"
         options={[
           {value: 0.25, text: 'x0.25'},

--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -111,7 +111,6 @@ export function PlaybackControls() {
         render={(framerate, paused) => (
           <Input
             title="Current framerate"
-            size={4}
             readOnly
             value={paused ? 'PAUSED' : `${framerate} FPS`}
           />

--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -62,6 +62,7 @@ export function PlaybackControls() {
   return (
     <div className={clsx(styles.controls, state.render && styles.disabled)}>
       <Select
+        className={clsx(styles.select)}
         title="Playback speed"
         options={[
           {value: 0.25, text: 'x0.25'},

--- a/packages/ui/src/index.scss
+++ b/packages/ui/src/index.scss
@@ -25,6 +25,10 @@
   font-size: 14px;
   accent-color: var(--theme);
 
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+
   &::-webkit-scrollbar {
     width: 16px;
     height: 16px;

--- a/packages/ui/src/index.scss
+++ b/packages/ui/src/index.scss
@@ -25,10 +25,6 @@
   font-size: 14px;
   accent-color: var(--theme);
 
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-
   &::-webkit-scrollbar {
     width: 16px;
     height: 16px;
@@ -74,4 +70,12 @@ button {
   appearance: none;
   border: 0;
   padding: 0;
+}
+
+select {
+  background: url("data:image/svg+xml;charset=UTF-8,%3csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M16.71 10.71L15.29 9.28998L12 12.59L8.71001 9.28998L7.29001 10.71L12 15.41L16.71 10.71Z' fill='gray'/%3e%3c/svg%3e")
+    no-repeat 100% 50%;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
 }


### PR DESCRIPTION
This small CSS fix removes the "glossy" effect of <select> tags in Safari