### PR TITLE
feat(core): add `debug` helper function

### DIFF
--- a/packages/core/src/utils/debug.test.ts
+++ b/packages/core/src/utils/debug.test.ts
@@ -1,0 +1,51 @@
+import {describe, test, beforeEach, expect, vi} from 'vitest';
+import {setProject, useLogger, debug} from '../utils';
+import {Project, ProjectMetadata} from '../Project';
+import {Meta} from '../Meta';
+import {LogLevel, LogPayload} from '../Logger';
+import {Rect, Vector2} from '../types';
+
+describe('debug()', () => {
+  beforeEach(() => {
+    setProject(new Project({name: 'test', scenes: []}));
+  });
+
+  test.each([
+    ['Strings', 'test', {message: 'test'}],
+    ['Numbers', 5, {message: '5'}],
+    ['Null', null, {message: 'null'}],
+    ['Undefined', undefined, {message: 'undefined'}],
+    ['NaN', NaN, {message: 'NaN'}],
+    ['Vector2', Vector2.one, {message: '{"x":1,"y":1}', object: Vector2.one}],
+    [
+      'Rect',
+      new Rect([10, 20, 30, 40]),
+      {
+        message: '{"x":10,"y":20,"width":30,"height":40}',
+        object: new Rect([10, 20, 30, 40]),
+      },
+    ],
+    [
+      'Arrays',
+      [5, 'test', Vector2.one],
+      {message: '[5,"test",{"x":1,"y":1}]', object: [5, 'test', Vector2.one]},
+    ],
+    ['Empty Array', [], {message: '[]', object: []}],
+    [
+      'Objects',
+      {foo: 'bar', baz: 'qux'},
+      {message: '{"foo":"bar","baz":"qux"}', object: {foo: 'bar', baz: 'qux'}},
+    ],
+    ['Empty Objects', {}, {message: '{}', object: {}}],
+  ])('log: %s', (_, payload, expected) => {
+    const spy = vi.fn();
+    useLogger().onLogged.subscribe(spy);
+
+    debug(payload);
+
+    expect(spy).toHaveBeenNthCalledWith(1, {
+      level: LogLevel.Debug,
+      ...expected,
+    });
+  });
+});

--- a/packages/core/src/utils/debug.ts
+++ b/packages/core/src/utils/debug.ts
@@ -1,0 +1,51 @@
+import {useLogger} from '.';
+import {LogPayload} from '../Logger';
+
+function stringify(value: any): string {
+  switch (typeof value) {
+    case 'string':
+      // Prevent strings from getting quoted again
+      return value;
+    case 'undefined':
+      // Prevent `undefined` from being turned into `null`
+      return 'undefined';
+    default:
+      // Prevent `NaN` from being turned into `null`
+      if (Number.isNaN(value)) {
+        return 'NaN';
+      }
+      return JSON.stringify(value);
+  }
+}
+
+/**
+ * Logs a debug message with an arbitrary payload.
+ *
+ * @remarks
+ * This method is a shortcut for calling `useLogger().debug()` which allows
+ * you to more easily log non-string values as well.
+ *
+ * @example
+ * ```ts
+ * export default makeScene2D(function* (view) {
+ *   const circle = createRef<Circle>();
+ *
+ *   view.add(
+ *     <Circle ref={circle} width={320} height={320} fill={'lightseagreen'} />,
+ *   );
+ *
+ *   debug(circle().position());
+ * });
+ * ```
+ *
+ * @param payload - The payload to log
+ */
+export function debug(payload: any) {
+  const result: LogPayload = {message: stringify(payload)};
+
+  if (payload && typeof payload === 'object') {
+    result.object = payload;
+  }
+
+  useLogger().debug(result);
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from './capitalize';
+export * from './debug';
 export * from './deprecate';
 export * from './DetailedError';
 export * from './errorToLog';


### PR DESCRIPTION
## Summary

Adds a new `debug` helper function to easily log debug messages with arbitrary payloads to the UI. See #267 for the rationale.

The function uses the logger's built-in functionality to pretty-print complex types by providing the `object` property in the log payload. Since it takes an additional mouse click to open the object dropdown in the UI, the `message` will be the JSON serialized payload itself. This way, you would still get a useful output at a glance which can often be enough when logging simpler types like `Vector2`.

```typescript
import {debug} from "@motion-canvas/core/lib/utils";

const v = Vector2.one;

debug(v);

// Is equivalent to
useLogger().debug({ message: JSON.serialize(v), object: v });
```

When logging primitive values like `string` and `number`,  providing the `object` property would only clutter up the output without adding any useful information. In these cases, the payload will simply be converted to a string using `JSON.stringify` while taking care of various edge-cases like `undefined`, `NaN` and not double quoting `string`s.

```ts
debug("Hello world");
// Is equivalent to
useLogger().debug("Hello world");

debug(500);
// Is equivalent to
useLogger().debug(JSON.stringify(500));

debug(undefined)
// Is equivalent to
useLogger().debug("undefined");
// since JSON.stringify(undefined) would return `null` which would lose information
```

I have included a test suite for this new function as well that should outline the important cases.

## Documentation

I've added a doc block to the function but I'm not sure what I need to do for it to show up in the API reference of the documentation. Just rebuilding the project locally didn't seem to do anything.

Closes #267 