### PR TITLE
feat(docs): always re-build api references in `build` mode

### DIFF
--- a/packages/docs/typedoc.js
+++ b/packages/docs/typedoc.js
@@ -16,7 +16,7 @@ module.exports = () => ({
   name: 'docusaurus-typedoc-plugin',
   async loadContent() {
     const dir = './src/generated';
-    if (fs.existsSync(dir)) {
+    if (fs.existsSync(dir) && process.env.NODE_ENV !== 'production') {
       const api = JSON.parse(
         await fs.promises.readFile(`${dir}/api.json`, 'utf8'),
       );


### PR DESCRIPTION
## What happens in this Pull Request

In this Pull Request the `typedoc` plugin has been changed to always re-build generated files when
running in `build` mode.

Before the API References did not get re-build when running `npm run docs:build` or using `npx lerna run build` which caused some confusion.

### Explanation
One can check if `docusaurus` runs in `build` mode using the `NODE_ENV` environment variable, which will be set to `production` if that's the case. If the variable is set, we ignore previously build files and re-build them, including the `api.json`.

---

Closes: #294