### PR TITLE
feat(2d): added smooth corners and corner sharpness to rect

### DIFF
--- a/packages/2d/src/components/Rect.ts
+++ b/packages/2d/src/components/Rect.ts
@@ -23,7 +23,7 @@ export class Rect extends Shape {
   @signal()
   public declare readonly smoothCorners: SimpleSignal<boolean, this>;
 
-  @initial(0.62)
+  @initial(0.6)
   @signal()
   public declare readonly cornerSharpness: SimpleSignal<number, this>;
 

--- a/packages/2d/src/components/Rect.ts
+++ b/packages/2d/src/components/Rect.ts
@@ -5,16 +5,27 @@ import {
 } from '@motion-canvas/core/lib/types';
 import {Shape, ShapeProps} from './Shape';
 import {drawRoundRect} from '../utils';
+import {initial, signal} from '../decorators';
 import {spacingSignal} from '../decorators/spacingSignal';
-import {SignalValue} from '@motion-canvas/core/lib/signals';
+import {SignalValue, SimpleSignal} from '@motion-canvas/core/lib/signals';
 
 export interface RectProps extends ShapeProps {
   radius?: SignalValue<PossibleSpacing>;
+  smoothCorners?: SignalValue<boolean>;
+  cornerSharpness?: SignalValue<number>;
 }
 
 export class Rect extends Shape {
   @spacingSignal('radius')
   public declare readonly radius: SpacingSignal<this>;
+
+  @initial(false)
+  @signal()
+  public declare readonly smoothCorners: SimpleSignal<boolean, this>;
+
+  @initial(0.62)
+  @signal()
+  public declare readonly cornerSharpness: SimpleSignal<number, this>;
 
   public constructor(props: RectProps) {
     super(props);
@@ -23,8 +34,10 @@ export class Rect extends Shape {
   protected override getPath(): Path2D {
     const path = new Path2D();
     const radius = this.radius();
+    const smoothCorners = this.smoothCorners();
+    const cornerSharpness = this.cornerSharpness();
     const rect = RectType.fromSizeCentered(this.size());
-    drawRoundRect(path, rect, radius);
+    drawRoundRect(path, rect, radius, smoothCorners, cornerSharpness);
 
     return path;
   }
@@ -37,8 +50,10 @@ export class Rect extends Shape {
     const path = new Path2D();
     const rippleSize = this.rippleSize();
     const radius = this.radius().addScalar(rippleSize);
+    const smoothCorners = this.smoothCorners();
+    const cornerSharpness = this.cornerSharpness();
     const rect = RectType.fromSizeCentered(this.size()).expand(rippleSize);
-    drawRoundRect(path, rect, radius);
+    drawRoundRect(path, rect, radius, smoothCorners, cornerSharpness);
 
     return path;
   }

--- a/packages/2d/src/utils/CanvasUtils.ts
+++ b/packages/2d/src/utils/CanvasUtils.ts
@@ -39,6 +39,8 @@ export function drawRoundRect(
   context: CanvasRenderingContext2D | Path2D,
   rect: Rect,
   radius: Spacing,
+  smoothCorners: boolean,
+  cornerSharpness: number,
 ) {
   if (
     radius.top === 0 &&
@@ -69,6 +71,56 @@ export function drawRoundRect(
     radius.top,
     rect,
   );
+
+  if (smoothCorners === true) {
+    const sharpness = (radius: number): number => {
+      const val = radius * cornerSharpness;
+      return radius - val;
+    };
+
+    context.moveTo(rect.left + topLeft, rect.top);
+    context.lineTo(rect.right - topRight, rect.top);
+
+    context.bezierCurveTo(
+      rect.right - sharpness(topRight),
+      rect.top,
+      rect.right,
+      rect.top + sharpness(topRight),
+      rect.right,
+      rect.top + topRight,
+    );
+    context.lineTo(rect.right, rect.bottom - bottomRight);
+
+    context.bezierCurveTo(
+      rect.right,
+      rect.bottom - sharpness(bottomRight),
+      rect.right - sharpness(bottomRight),
+      rect.bottom,
+      rect.right - bottomRight,
+      rect.bottom,
+    );
+    context.lineTo(rect.left + bottomRight, rect.bottom);
+
+    context.bezierCurveTo(
+      rect.left + sharpness(bottomLeft),
+      rect.bottom,
+      rect.left,
+      rect.bottom - sharpness(bottomLeft),
+      rect.left,
+      rect.bottom - bottomLeft,
+    );
+    context.lineTo(rect.left, rect.top + topLeft);
+
+    context.bezierCurveTo(
+      rect.left,
+      rect.top + sharpness(topLeft),
+      rect.left + sharpness(topLeft),
+      rect.top,
+      rect.left + topLeft,
+      rect.top,
+    );
+    return;
+  }
 
   context.moveTo(rect.left + topLeft, rect.top);
   context.arcTo(rect.right, rect.top, rect.right, rect.bottom, topRight);

--- a/packages/2d/src/utils/CanvasUtils.ts
+++ b/packages/2d/src/utils/CanvasUtils.ts
@@ -72,7 +72,7 @@ export function drawRoundRect(
     rect,
   );
 
-  if (smoothCorners === true) {
+  if (smoothCorners) {
     const sharpness = (radius: number): number => {
       const val = radius * cornerSharpness;
       return radius - val;
@@ -99,7 +99,7 @@ export function drawRoundRect(
       rect.right - bottomRight,
       rect.bottom,
     );
-    context.lineTo(rect.left + bottomRight, rect.bottom);
+    context.lineTo(rect.left + bottomLeft, rect.bottom);
 
     context.bezierCurveTo(
       rect.left + sharpness(bottomLeft),


### PR DESCRIPTION
Added `smoothCorners` and `cornerSharpness` to `Rect` according to #281 

**Usage:**
```xml
<Rect
   width={100}
   height={100}
   radius={20}
   cornerSharpness={.94}
   smoothCorners={true}
/>
```
<img width="500" alt="image" src="https://user-images.githubusercontent.com/35671734/218222615-b7330770-ef72-4b0f-8d4a-38f5799d041c.png">


```xml
view.add([
    <Rect 
       width={100} 
       height={100} 
       fill={'lightseagreen'} 
       radius={20}
    >
      <Text
        fontFamily={'system-ui'}
        y={90}
        fontSize={20}
        fill={'lightseagreen'}
      >
        Default Corners
      </Text>
    </Rect>,
    <Rect
      width={100}
      height={100}
      fill={'pink'}
      x={500}
      radius={20}
      smoothCorners={true}
      cornerSharpness={0.68}
    >
      <Text
        fontFamily={'system-ui'}
        y={90}
        fontSize={20}
        fill={'pink'}
      >
        Smooth Corners
      </Text>
    </Rect>,
  ]);
```
