### PR TITLE
docs: fix incorrect branch name in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Motion Canvas follows [semantic versioning][semver].
 1. Fork the motion-canvas/motion-canvas repo.
 2. In your forked repo, create a new branch for your changes:
    ```shell
-   git checkout -b my-fix-branch master
+   git checkout -b my-fix-branch main
    ```
 3. Update the code.
 4. Commit your changes using a **descriptive commit message** that follows the


### PR DESCRIPTION
Fixes an incorrect branch name in the contribution guide. It erroneously referred to the `main` branch as `master`.