### PR TITLE
fix(2d): fix layout calculation for nodes not explicitly added to view

### DIFF
--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -375,6 +375,7 @@ export class Node implements Promisable<Node> {
     }
   }
 
+  private view2D: View2D;
   private realChildren: Node[] = [];
   public readonly parent = createSignal<Node | null>(null);
   public readonly properties = getPropertiesOf(this);
@@ -382,7 +383,9 @@ export class Node implements Promisable<Node> {
   public readonly creationStack?: string;
 
   public constructor({children, spawner, key, ...rest}: NodeProps) {
-    this.key = useScene2D()?.registerNode(this, key) ?? key ?? '';
+    const scene = useScene2D();
+    this.key = scene.registerNode(this, key);
+    this.view2D = scene.getView();
     this.creationStack = new Error().stack;
     initialize(this, {defaults: rest});
     for (const {signal} of this) {
@@ -525,9 +528,8 @@ export class Node implements Promisable<Node> {
     return new DOMMatrix();
   }
 
-  @computed()
   public view(): View2D | null {
-    return this.parent()?.view() ?? null;
+    return this.view2D;
   }
 
   /**


### PR DESCRIPTION
Allows for proper layout calculation for elements that haven't explicitly been added to the scene's view yet.

For reference: This came up as part of #328 where it would allow us to have multiple cameras render the same "view" without having to add it to the scene hierarchy first.