### PR TITLE
fix(core): playback speed is reset after saving with faulty code (#204).

### DIFF
--- a/packages/core/src/Project.ts
+++ b/packages/core/src/Project.ts
@@ -331,14 +331,11 @@ export class Project {
   public async recalculate() {
     this.previousScene = null;
 
-    const speed = this._speed;
-    this._speed = 1;
     this.frame = 0;
     const scenes = [...this.scenes.current];
     for (const scene of scenes) {
       await scene.recalculate();
     }
-    this._speed = speed;
     this.scenes.current = scenes;
   }
 

--- a/packages/core/src/Project.ts
+++ b/packages/core/src/Project.ts
@@ -331,11 +331,19 @@ export class Project {
   public async recalculate() {
     this.previousScene = null;
 
+    const speed = this._speed;
     this.frame = 0;
     const scenes = [...this.scenes.current];
-    for (const scene of scenes) {
-      await scene.recalculate();
+
+    try {
+      this._speed = 1;
+      for (const scene of scenes) {
+        await scene.recalculate();
+      }
+    } finally {
+      this._speed = speed;
     }
+
     this.scenes.current = scenes;
   }
 


### PR DESCRIPTION
Removing this code fixes the problem, but it's unclear why it was added in the first place. I don't see any issue by removing this.
However, please do let me know if this code is essential for a particular scenario. If that is the case, we'll explore alternative solutions to fix the issue.

Issue(#204)