### PR TITLE
docs: add update guide

### DIFF
--- a/packages/docs/docs/updating.mdx
+++ b/packages/docs/docs/updating.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 100
+slug: /updating
+---
+
+# Update Guide
+
+The latest patch notes can be found
+[here](https://github.com/motion-canvas/motion-canvas/releases).
+
+To update all the `@motion-canvas` packages to the latest version use the
+following:
+
+```bash
+npm update --save @motion-canvas/2d @motion-canvas/core @motion-canvas/ui @motion-canvas/vite-plugin
+```
+
+## Toubleshooting
+
+If you get any errors, try removing `package-lock.json` and the `node_modules`
+folder, then run `npm install` again.


### PR DESCRIPTION
## What changed in this Pull Request
A new page for the update guide has been added to the documentation.
In the sidebar it is located below the `Advanced` section since it doesn't really fit to any of the other topics. (Inspired by NextJS Documentation)

This page might contain migration guides as well as breaking changes once we have some.

---

Closes #288 