### PR TITLE
fix(vite-plugin): Ignore query param in devserver

### DIFF
--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -296,13 +296,16 @@ export default ({
           return;
         }
 
-        if (req.url === '/') {
+        const url = req.url
+          ? new URL(req.url, `http://${req.headers.host}`)
+          : undefined;
+        if (url?.pathname === '/') {
           res.setHeader('Content-Type', 'text/html');
           res.end(createHtml('/@id/__x00__virtual:editor'));
           return;
         }
 
-        const name = req.url?.slice(1);
+        const name = url?.pathname?.slice(1);
         if (name && name in projectLookup) {
           res.setHeader('Content-Type', 'text/html');
           res.end(createHtml(`/@id/__x00__virtual:editor?project=${name}`));


### PR DESCRIPTION
The previous implementation tested the full url, including query parameters against the '/' path. Any query parameter in the URL would cause a 404 instead of loading the editor.

Parsing the request URL with the URL class gives us access to the pathname, which does not include query parameters and can be safely compared.

---

I ran into the issue when testing in VS Code and opening `http://localhost:9000/` in the builtin 'Simple Browser'. It simply resulted in a blank page. After some digging I noticed that it automatically appends the query parameter `/?vscodeBrowserReqId=<random number>`, causing the vite server to respond with 404.