### PR TITLE
feat(ui): shift + right arrow moves to last frame

### DIFF
--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -46,6 +46,11 @@ export function PlaybackControls() {
             break;
           case 'ArrowRight':
             event.preventDefault();
+            if (event.shiftKey) {
+              player.requestSeek(state.endFrame);
+              return;
+            }
+
             player.requestNextFrame();
             break;
           case 'm':


### PR DESCRIPTION
Press shift + right arrow in the editor to move to the last frame for easier navigation.

Implements #353