### PR TITLE
feat(2d): unify layout properties

### DIFF
--- a/packages/2d/src/components/CodeBlock.ts
+++ b/packages/2d/src/components/CodeBlock.ts
@@ -18,7 +18,7 @@ import {
   tween,
 } from '@motion-canvas/core/lib/tweening';
 import {threadable} from '@motion-canvas/core/lib/decorators';
-import {Length} from '../partials';
+import {DesiredLength} from '../partials';
 import {SerializedVector2, Vector2} from '@motion-canvas/core/lib/types';
 import {
   createComputedAsync,
@@ -131,7 +131,7 @@ export class CodeBlock extends Shape {
     return new Vector2(width, parseFloat(this.styles.lineHeight));
   }
 
-  protected override desiredSize(): SerializedVector2<Length> {
+  protected override desiredSize(): SerializedVector2<DesiredLength> {
     const custom = super.desiredSize();
     const tokensSize = this.getTokensSize(this.parsed());
     return {

--- a/packages/2d/src/components/Image.ts
+++ b/packages/2d/src/components/Image.ts
@@ -8,7 +8,7 @@ import {
 } from '@motion-canvas/core/lib/types';
 import {drawImage} from '../utils';
 import {Rect, RectProps} from './Rect';
-import {Length} from '../partials';
+import {DesiredLength} from '../partials';
 import {
   DependencyContext,
   SignalValue,
@@ -39,7 +39,7 @@ export class Image extends Rect {
     super(props);
   }
 
-  protected override desiredSize(): SerializedVector2<Length> {
+  protected override desiredSize(): SerializedVector2<DesiredLength> {
     const custom = super.desiredSize();
     if (custom.x === null && custom.y === null) {
       const image = this.image();

--- a/packages/2d/src/components/Layout.ts
+++ b/packages/2d/src/components/Layout.ts
@@ -44,6 +44,7 @@ import {drawLine, lineTo} from '../utils';
 import {spacingSignal} from '../decorators/spacingSignal';
 import {
   createSignal,
+  Signal,
   SignalValue,
   SimpleSignal,
 } from '@motion-canvas/core/lib/signals';
@@ -149,17 +150,13 @@ export class Layout extends Node {
   @signal()
   public declare readonly alignItems: SimpleSignal<FlexAlign, this>;
   @initial(0)
-  @signal()
-  public declare readonly gap: SimpleSignal<Length, this>;
-  @signal()
-  public declare readonly rowGap: SimpleSignal<Length, this>;
-  protected getDefaultRowGap() {
-    return this.gap();
+  @vector2Signal({x: 'columnGap', y: 'rowGap'})
+  public declare readonly gap: Vector2LengthSignal<this>;
+  public get columnGap(): Signal<Length, number, this> {
+    return this.gap.x;
   }
-  @signal()
-  public declare readonly columnGap: SimpleSignal<Length, this>;
-  protected getDefaultColumnGap() {
-    return this.gap();
+  public get rowGap(): Signal<Length, number, this> {
+    return this.gap.y;
   }
 
   @defaultStyle('font-family')
@@ -367,6 +364,12 @@ export class Layout extends Node {
   @initial({x: null, y: null})
   @vector2Signal({x: 'width', y: 'height'})
   public declare readonly size: Vector2LengthSignal<this>;
+  public get width(): Signal<Length, number, this> {
+    return this.size.x;
+  }
+  public get height(): Signal<Length, number, this> {
+    return this.size.y;
+  }
 
   /**
    * Get the desired size of this node.
@@ -745,8 +748,8 @@ export class Layout extends Node {
 
     this.element.style.justifyContent = this.justifyContent();
     this.element.style.alignItems = this.alignItems();
-    this.element.style.rowGap = this.parseLength(this.rowGap());
-    this.element.style.columnGap = this.parseLength(this.columnGap());
+    this.element.style.columnGap = this.parseLength(this.gap.x());
+    this.element.style.rowGap = this.parseLength(this.gap.y());
 
     if (this.sizeLockCounter() > 0) {
       this.element.style.flexGrow = '0';

--- a/packages/2d/src/components/Line.ts
+++ b/packages/2d/src/components/Line.ts
@@ -14,7 +14,7 @@ import {
   Vector2,
 } from '@motion-canvas/core/lib/types';
 import {clamp} from '@motion-canvas/core/lib/tweening';
-import {Length} from '../partials';
+import {DesiredLength} from '../partials';
 import {Layout} from './Layout';
 import {
   CurveDrawingInfo,
@@ -84,7 +84,7 @@ export class Line extends Shape {
     this
   >;
 
-  protected override desiredSize(): SerializedVector2<Length> {
+  protected override desiredSize(): SerializedVector2<DesiredLength> {
     return this.childrenRect().size;
   }
 

--- a/packages/2d/src/components/Video.ts
+++ b/packages/2d/src/components/Video.ts
@@ -8,7 +8,7 @@ import {useProject, useThread} from '@motion-canvas/core/lib/utils';
 import {PlaybackState} from '@motion-canvas/core';
 import {clamp} from '@motion-canvas/core/lib/tweening';
 import {Rect, RectProps} from './Rect';
-import {Length} from '../partials';
+import {DesiredLength} from '../partials';
 import {
   DependencyContext,
   SignalValue,
@@ -63,7 +63,7 @@ export class Video extends Rect {
     return this.video().duration;
   }
 
-  protected override desiredSize(): SerializedVector2<Length> {
+  protected override desiredSize(): SerializedVector2<DesiredLength> {
     const custom = super.desiredSize();
     if (custom.x === null && custom.y === null) {
       const image = this.video();

--- a/packages/2d/src/components/View2D.ts
+++ b/packages/2d/src/components/View2D.ts
@@ -25,7 +25,7 @@ export class View2D extends Layout {
       composite: true,
       fontFamily: 'Roboto',
       fontSize: 48,
-      lineHeight: 64,
+      lineHeight: '120%',
       textWrap: false,
       fontStyle: 'normal',
       ...props,

--- a/packages/2d/src/partials/types.ts
+++ b/packages/2d/src/partials/types.ts
@@ -46,9 +46,22 @@ export type LayoutMode = boolean | null;
  * - `number` - the desired length in pixels
  * - `${number}%` - a string with the desired length in percents, for example
  *                  `'50%'`
- * - `null` - an automatic length (equivalent to `auto` in CSS)
  */
-export type Length = number | `${number}%` | null;
+export type Length = number | `${number}%`;
+
+/**
+ * Represents a desired length used internally by layout Nodes.
+ *
+ * @remarks
+ * When the desired length is set to `null` it represents a default value for
+ * whatever property it describes.
+ */
+export type DesiredLength = Length | null;
+
+/**
+ * Represents a length limit used by layout properties such as `max-width`.
+ */
+export type LengthLimit = Length | null | 'max-content' | 'min-content';
 
 export type PossibleCanvasStyle = null | PossibleColor | Gradient | Pattern;
 export type CanvasStyle = null | Color | Gradient | Pattern;


### PR DESCRIPTION
- External interfaces for `size` and `lineHeight` no longer use `null` values. Users can use `DEFAULT` to achieve the same thing.
- `lineHeight` supports inheritance like other CSS properties.
- `gap` is now a compound `Vector2` signal.
- Added `width` and `height` as shorthands for `size.x` and `size.y` respectively.

Closes: #352