### PR TITLE
feat(2d): add moveBelow, moveAbove and moveTo methods to Node

### DIFF
--- a/packages/docs/docs/getting-started/hierarchy.mdx
+++ b/packages/docs/docs/getting-started/hierarchy.mdx
@@ -141,6 +141,21 @@ following helper methods:
 <ApiSnippet url={'/api/2d/components/Node#moveToBottom'} />
 <hr />
 
+## `Node.moveTo`
+
+<ApiSnippet url={'/api/2d/components/Node#moveTo'} />
+<hr />
+
+## `Node.moveAbove`
+
+<ApiSnippet url={'/api/2d/components/Node#moveAbove'} />
+<hr />
+
+## `Node.moveBelow`
+
+<ApiSnippet url={'/api/2d/components/Node#moveBelow'} />
+<hr />
+
 ## `Node.removeChildren`
 
 <ApiSnippet url={'/api/2d/components/Node#removeChildren'} />

--- a/packages/docs/typedoc.js
+++ b/packages/docs/typedoc.js
@@ -176,7 +176,7 @@ async function parseTypes(options, projectName, externalProject) {
           }
         }
 
-        return reference.href;
+        return reference?.href;
       }
     }
 


### PR DESCRIPTION
This PR adds three methods to the `Node` base class to more easily position a node relative to a specific other node in its parent's hierarchy.

- `moveTo` moves to node to the specified position in the parent's children array
- `moveBelow` moves the node one position below the provided sibling node. Will not move the node if it is already positioned lower than the sibling. This method logs an error if the provided node is not a sibling of the current node.
- `moveAbove` moves the node one position above the provided sibling node. Will not move the node if it is already positioned higher than the sibling. This method logs an error if the provided node is not a sibling of the current node.