### PR TITLE
feat(core): add step parameter to range function

### DIFF
--- a/packages/core/src/utils/range.test.ts
+++ b/packages/core/src/utils/range.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, test} from 'vitest';
+import {range} from './range';
+
+describe('range', () => {
+  test.each([
+    ['ascending', 4, [0, 1, 2, 3]],
+    ['descending', -4, [0, -1, -2, -3]],
+  ])(
+    'generates an array of the provided length, starting at 0: %s',
+    (_, length, expected) => {
+      expect(range(length)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    ['ascending', 3, 6, [3, 4, 5]],
+    ['descending', 6, 3, [6, 5, 4]],
+  ])(
+    'generates an array from start to end (exclusive): %s',
+    (_, from, to, expected) => {
+      expect(range(from, to)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    ['ascending', 3, 6, 0.5, [3, 3.5, 4, 4.5, 5, 5.5]],
+    ['descending', 6, 3, -0.5, [6, 5.5, 5, 4.5, 4, 3.5]],
+  ])(
+    'generates an array from start to end (exclusive) with the provided step size: %s',
+    (_, from, to, step, expected) => {
+      expect(range(from, to, step)).toEqual(expected);
+    },
+  );
+
+  test.each([
+    ['ascending', 3, 6, -1],
+    ['descending', 6, 3, 1],
+  ])(
+    'returns an empty array if the step size goes in the wrong direction: %s',
+    (_, from, to, step) => {
+      expect(range(from, to, step)).toEqual([]);
+    },
+  );
+});

--- a/packages/core/src/utils/range.ts
+++ b/packages/core/src/utils/range.ts
@@ -3,7 +3,8 @@
  *
  * @example
  * ```ts
- * const array = range(3); // [0, 1, 2]
+ * const array1 = range(3); // [0, 1, 2]
+ * const array2 = range(-3); // [0, -1, -2]
  * ```
  *
  * @param length - The length of the array.
@@ -14,14 +15,29 @@ export function range(length: number): number[];
  *
  * @example
  * ```ts
- * const array = range(3, 7); // [3, 4, 5, 6]
+ * const array1 = range(3, 7); // [3, 4, 5, 6]
+ * const array2 = range(7, 3); // [7, 6, 5, 4]
  * ```
  *
  * @param from - The start of the range.
  * @param to - The end of the range. `to` itself is not included in the result.
  */
 export function range(from: number, to: number): number[];
-export function range(first: number, second?: number): number[] {
+/**
+ * Create an array containing a range of numbers.
+ *
+ * @example
+ * ```ts
+ * const array1 = range(1, 2, 0.25); // [1, 1.25, 1.5, 1.75]
+ * const array2 = range(2, 1, -0.25); // [2, 1.75, 1.5, 1.25]
+ * ```
+ *
+ * @param from - The start of the range.
+ * @param to - The end of the range. `to` itself is not included in the result.
+ * @param step - The value by which to increment or decrement.
+ */
+export function range(from: number, to: number, step: number): number[];
+export function range(first: number, second?: number, step?: number): number[] {
   let from = 0;
   let to = first;
   if (second !== undefined) {
@@ -29,15 +45,15 @@ export function range(first: number, second?: number): number[] {
     to = second;
   }
 
+  step = step === undefined ? (from < to ? 1 : -1) : step;
+
   const array = [];
-  if (from > to) {
-    for (let i = from; i > to; i--) {
-      array.push(i);
-    }
-  } else {
-    for (let i = from; i < to; i++) {
-      array.push(i);
-    }
+  let length = Math.max(Math.ceil((to - from) / step), 0);
+  let index = 0;
+
+  while (length--) {
+    array[index++] = from;
+    from += step;
   }
 
   return array;


### PR DESCRIPTION
Adds an optional third parameter `step` to the `range` function which allows users to define the step size of the generated range.

I added a test for the `range` function that covers all the existing and new functionality. I also updated the examples in the existing doc blocks to also show the descending case. As it wasn't super obvious to me how `range(-4)` would behave, for instance.