### PR TITLE
feat(2d): add z-index property to nodes

### DIFF
--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -386,7 +386,9 @@ export class Node implements Promisable<Node> {
 
   @computed()
   protected sortedChildren(): Node[] {
-    return this.children().sort((a, b) => Math.sign(a.zIndex() - b.zIndex()));
+    return [...this.children()].sort((a, b) =>
+      Math.sign(a.zIndex() - b.zIndex()),
+    );
   }
 
   protected view2D: View2D;

--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -56,6 +56,7 @@ export interface NodeProps {
   scaleX?: SignalValue<number>;
   scaleY?: SignalValue<number>;
   scale?: SignalValue<PossibleVector2>;
+  zIndex?: SignalValue<number>;
 
   opacity?: SignalValue<number>;
   filters?: SignalValue<Filter[]>;
@@ -248,6 +249,10 @@ export class Node implements Promisable<Node> {
     return scale.div(parentScale);
   }
 
+  @initial(0)
+  @signal()
+  public declare readonly zIndex: SimpleSignal<number, this>;
+
   @initial(false)
   @signal()
   public declare readonly cache: SimpleSignal<boolean, this>;
@@ -377,6 +382,11 @@ export class Node implements Promisable<Node> {
     } else {
       this.realChildren = children;
     }
+  }
+
+  @computed()
+  protected sortedChildren(): Node[] {
+    return this.children().sort((a, b) => Math.sign(a.zIndex() - b.zIndex()));
   }
 
   protected view2D: View2D;
@@ -1148,7 +1158,7 @@ export class Node implements Promisable<Node> {
   }
 
   protected drawChildren(context: CanvasRenderingContext2D) {
-    for (const child of this.children()) {
+    for (const child of this.sortedChildren()) {
       child.render(context);
     }
   }


### PR DESCRIPTION
Adds a `zIndex` signal to `Node` and sorts children by this value before drawing them.