### PR TITLE
feat: upgraded code-fns for new theme options and lazy loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6298,24 +6298,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@wooorm/starry-night": {
-      "version": "1.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "import-meta-resolve": "^2.0.0",
-        "vscode-oniguruma": "^1.0.0",
-        "vscode-textmate": "^7.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@wooorm/starry-night/node_modules/vscode-textmate": {
-      "version": "7.0.3",
-      "license": "MIT"
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "license": "BSD-3-Clause"
@@ -6558,6 +6540,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ=="
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -8029,11 +8016,33 @@
       }
     },
     "node_modules/code-fns": {
-      "version": "0.8.2",
-      "license": "MIT",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/code-fns/-/code-fns-0.9.0.tgz",
+      "integrity": "sha512-UZl4Oujhmz5n3BLjTMdjjp3wz43V+d/qfEqQhEkvfNNmt5jwcBJbqMnilc08quyNIUioLvTsR08BzEpQpKTIHQ==",
       "dependencies": {
-        "@wooorm/starry-night": "^1.2.0"
+        "shiki": "^0.14.1"
       }
+    },
+    "node_modules/code-fns/node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
+    "node_modules/code-fns/node_modules/shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/code-fns/node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "node_modules/collapse-white-space": {
       "version": "1.0.6",
@@ -12394,14 +12403,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -20674,6 +20675,14 @@
         }
       }
     },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.2.1.tgz",
+      "integrity": "sha512-38TPuRUHC+s62JFhZxWtNStujhsav/qFEspDa/+huGCUvn0SbXdXexnxQ+UgIs2pmBnd/xd70fm1R9jW/0qALA==",
+      "dependencies": {
+        "vite": "^3"
+      }
+    },
     "node_modules/vitest": {
       "version": "0.25.5",
       "license": "MIT",
@@ -20728,8 +20737,9 @@
       }
     },
     "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "license": "MIT"
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
     },
     "node_modules/vscode-textmate": {
       "version": "6.0.0",
@@ -21530,7 +21540,7 @@
       "license": "MIT",
       "dependencies": {
         "@motion-canvas/core": "^2.5.0",
-        "code-fns": "^0.8.2",
+        "code-fns": "^0.9.0",
         "mathjax-full": "^3.2.2"
       },
       "devDependencies": {
@@ -21651,7 +21661,8 @@
       "license": "MIT",
       "dependencies": {
         "@motion-canvas/2d": "*",
-        "@motion-canvas/core": "*"
+        "@motion-canvas/core": "*",
+        "vite-plugin-wasm": "^3.2.1"
       },
       "devDependencies": {
         "@motion-canvas/ui": "*",
@@ -24913,7 +24924,7 @@
       "requires": {
         "@motion-canvas/core": "^2.5.0",
         "@motion-canvas/internal": "0.0.0",
-        "code-fns": "^0.8.2",
+        "code-fns": "^0.9.0",
         "mathjax-full": "^3.2.2"
       }
     },
@@ -25002,7 +25013,8 @@
         "@motion-canvas/2d": "*",
         "@motion-canvas/core": "*",
         "@motion-canvas/ui": "*",
-        "@motion-canvas/vite-plugin": "*"
+        "@motion-canvas/vite-plugin": "*",
+        "vite-plugin-wasm": "^3.2.1"
       }
     },
     "@motion-canvas/ui": {
@@ -26090,20 +26102,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@wooorm/starry-night": {
-      "version": "1.3.1",
-      "requires": {
-        "@types/hast": "^2.0.0",
-        "import-meta-resolve": "^2.0.0",
-        "vscode-oniguruma": "^1.0.0",
-        "vscode-textmate": "^7.0.0"
-      },
-      "dependencies": {
-        "vscode-textmate": {
-          "version": "7.0.3"
-        }
-      }
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0"
     },
@@ -26255,6 +26253,11 @@
     },
     "ansi-regex": {
       "version": "5.0.1"
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -27157,9 +27160,34 @@
       "peer": true
     },
     "code-fns": {
-      "version": "0.8.2",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/code-fns/-/code-fns-0.9.0.tgz",
+      "integrity": "sha512-UZl4Oujhmz5n3BLjTMdjjp3wz43V+d/qfEqQhEkvfNNmt5jwcBJbqMnilc08quyNIUioLvTsR08BzEpQpKTIHQ==",
       "requires": {
-        "@wooorm/starry-night": "^1.2.0"
+        "shiki": "^0.14.1"
+      },
+      "dependencies": {
+        "jsonc-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+          "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+        },
+        "shiki": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+          "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+          "requires": {
+            "ansi-sequence-parser": "^1.1.0",
+            "jsonc-parser": "^3.2.0",
+            "vscode-oniguruma": "^1.7.0",
+            "vscode-textmate": "^8.0.0"
+          }
+        },
+        "vscode-textmate": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+          "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
+        }
       }
     },
     "collapse-white-space": {
@@ -29851,9 +29879,6 @@
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
       }
-    },
-    "import-meta-resolve": {
-      "version": "2.1.0"
     },
     "imurmurhash": {
       "version": "0.1.4"
@@ -35076,6 +35101,14 @@
         "rollup": "^2.79.1"
       }
     },
+    "vite-plugin-wasm": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.2.1.tgz",
+      "integrity": "sha512-38TPuRUHC+s62JFhZxWtNStujhsav/qFEspDa/+huGCUvn0SbXdXexnxQ+UgIs2pmBnd/xd70fm1R9jW/0qALA==",
+      "requires": {
+        "vite": "^3"
+      }
+    },
     "vitest": {
       "version": "0.25.5",
       "requires": {
@@ -35096,7 +35129,9 @@
       }
     },
     "vscode-oniguruma": {
-      "version": "1.6.2"
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
     },
     "vscode-textmate": {
       "version": "6.0.0",

--- a/packages/2d/package.json
+++ b/packages/2d/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@motion-canvas/core": "^2.5.0",
-    "code-fns": "^0.8.2",
+    "code-fns": "^0.9.0",
     "mathjax-full": "^3.2.2"
   }
 }

--- a/packages/2d/src/components/CodeBlock.ts
+++ b/packages/2d/src/components/CodeBlock.ts
@@ -54,7 +54,7 @@ export class CodeBlock extends Shape {
   @signal()
   public declare readonly language: SimpleSignal<Lang, this>;
 
-  @initial(undefined)
+  @initial(null)
   @signal()
   public declare readonly stockTheme: SimpleSignal<Theme | undefined, this>;
 
@@ -64,23 +64,24 @@ export class CodeBlock extends Shape {
   @computed()
   protected isReady() {
     const language = this.language();
-    const theme = this.stockTheme();
-    if (
-      !CodeBlock.loadedLanguages.has(language) ||
-      (theme != null && !CodeBlock.loadedThemes.has(theme))
-    ) {
+    if (!CodeBlock.loadedLanguages.has(language)) {
+      CodeBlock.loadedLanguages.set(language, false);
       DependencyContext.collectPromise(
-        ready({
-          languages: [language],
-          themes: theme != null ? [theme] : [],
-        }).then(() => {
+        ready({languages: [language]}).then(() => {
           CodeBlock.loadedLanguages.set(language, true);
-          if (theme != null) {
-            CodeBlock.loadedThemes.set(theme, true);
-          }
         }),
       );
       return false;
+    }
+
+    const theme = this.stockTheme();
+    if (theme != null && !CodeBlock.loadedThemes.has(theme)) {
+      CodeBlock.loadedThemes.set(theme, false);
+      DependencyContext.collectPromise(
+        ready({themes: [theme]}).then(() => {
+          CodeBlock.loadedThemes.set(theme, true);
+        }),
+      );
     }
 
     return (
@@ -102,7 +103,7 @@ export class CodeBlock extends Shape {
   @signal()
   public declare readonly code: Signal<CodeTree | string, CodeTree, this>;
 
-  @initial(undefined)
+  @initial(null)
   @signal()
   public declare readonly theme: Signal<CodeStyle | null, CodeStyle, this>;
 

--- a/packages/2d/src/components/index.ts
+++ b/packages/2d/src/components/index.ts
@@ -11,3 +11,4 @@ export * from './Text';
 export * from './types';
 export * from './Video';
 export * from './View2D';
+export * from './CodeBlock';


### PR DESCRIPTION
* CodeBlock is now exported
* new stockTheme option with common theme options like github and nord
* new, more granular theme options
* uses the shiki library

closes #396, closes #322