### PR TITLE
fix(2d): textDirection property for RTL/LTR text

### DIFF
--- a/packages/2d/src/components/Layout.ts
+++ b/packages/2d/src/components/Layout.ts
@@ -94,6 +94,7 @@ export interface LayoutProps extends NodeProps {
   lineHeight?: SignalValue<Length>;
   letterSpacing?: SignalValue<number>;
   textWrap?: SignalValue<TextWrap>;
+  textDirection?: SignalValue<CanvasDirection>;
 
   size?: SignalValue<PossibleVector2<Length>>;
   offsetX?: SignalValue<number>;
@@ -196,6 +197,9 @@ export class Layout extends Node {
   })
   @signal()
   public declare readonly textWrap: SimpleSignal<TextWrap, this>;
+  @initial('inherit')
+  @signal()
+  public declare readonly textDirection: SimpleSignal<CanvasDirection, this>;
 
   @cloneable(false)
   @inspectable(false)

--- a/packages/2d/src/components/Shape.ts
+++ b/packages/2d/src/components/Shape.ts
@@ -65,6 +65,11 @@ export abstract class Shape extends Layout {
     super(props);
   }
 
+  protected applyText(context: CanvasRenderingContext2D) {
+    context.direction = this.textDirection();
+    this.element.dir = this.textDirection();
+  }
+
   protected applyStyle(context: CanvasRenderingContext2D) {
     context.fillStyle = resolveCanvasStyle(this.fill(), context);
     context.strokeStyle = resolveCanvasStyle(this.stroke(), context);

--- a/packages/2d/src/components/Text.ts
+++ b/packages/2d/src/components/Text.ts
@@ -43,6 +43,7 @@ export class Text extends Shape {
   protected override draw(context: CanvasRenderingContext2D) {
     this.requestFontUpdate();
     this.applyStyle(context);
+    this.applyText(context);
     context.font = this.styles.font;
 
     const parentRect = this.element.getBoundingClientRect();


### PR DESCRIPTION
Currently, the Text component defaults to LTR text direction and hence when setting the offset to -1,-1, we see a slight shift like for RTL texts like this:

https://user-images.githubusercontent.com/24268/220945677-29007823-f869-401c-a491-3c0fd486252b.mp4

With the new property `textDirection` set to `rtl`, we don't see such a shift and text stays steady just like for LTR:

https://user-images.githubusercontent.com/24268/220946030-8b0b7c6e-cd04-442f-bec4-ebfff4c13c83.mp4

Looking for feedback, happyt to make further adjustments. @aarthificial 
