### PR TITLE
Update time-events.mdx

### DIFF
--- a/packages/docs/docs/getting-started/time-events.mdx
+++ b/packages/docs/docs/getting-started/time-events.mdx
@@ -29,6 +29,8 @@ through the editor. With the use of [`waitUntil`](/api/core/flow#waitUntil) you
 can pause the animation without specifying the actual duration:
 
 ```ts
+useScene().timeEvents.register('event');
+
 yield * animationOne();
 yield * waitUntil('event'); // wait for an event called "event"
 yield * animationTwo();


### PR DESCRIPTION
Without "event registration" it shown in editor "fixed" to time where "waitUntil" called