### PR TITLE
feat(ui): Add option for 0.25x scale in sidebar

### DIFF
--- a/packages/ui/src/components/sidebar/Rendering.tsx
+++ b/packages/ui/src/components/sidebar/Rendering.tsx
@@ -16,6 +16,7 @@ export function Rendering() {
   const {width, height} = player.project.getSize();
 
   const scales = [
+    {value: 0.25, text: '0.25x (Quarter)'},
     {value: 0.5, text: `0.5x (Half)`},
     {value: 1, text: `1.0x (Full)`},
     {value: 2, text: `2.0x (Double)`},


### PR DESCRIPTION
This is a completely trivial change.
The main reason is Discord's upload limit of 8 GB for non-boosted servers.


Edit: Sorry about the commit lint fail - I remember from the discord that aarthificial can rename the commits anyways.