### PR TITLE
Fixed a sentence that was hard to reed and wrong.

### DIFF
--- a/packages/docs/docs/components/nodes.mdx
+++ b/packages/docs/docs/components/nodes.mdx
@@ -15,10 +15,11 @@ import texSource from '!!raw-loader!@motion-canvas/examples/src/scenes/tex';
 
 ## A note on tweening LaTeX
 
-Because we use a canvas renderer, we're rendering the LaTeX to an image instead
-using a full graphics backend to render the TeX. This means that for all intents
-and purposes, LaTeX should be treated as if it were an image rather than more
-flexible TeX rendering like you may see in other software.
+Because we use a canvas renderer, we're rendering the LaTeX to an image.
+This means we're not using a full graphics backend to render the TeX. Thus,
+for all intents using a full graphics backend to render the TeX. This means
+that for all intents and purposes, LaTeX should be treated as if it were an
+image rather than more flexible TeX rendering like you may see in other software.
 
 In other words, opacity, position, size, etc. should be fine to tween, but we do
 not recommend tweening the `tex` signal.


### PR DESCRIPTION
> Originally in: https://github.com/motion-canvas/motion-canvas.github.io/pull/6

This was wrong and very hard to read. So I rewrote it (the `instead of` was `instead`, and overall the whole thing was long)

<img width="663" alt="Screenshot 2023-02-17 at 1 18 52 AM" src="https://user-images.githubusercontent.com/2157285/219494686-4df06dad-126f-4aef-a40b-ebd84469d7ed.png">


Since this page looks like a complied markdown, I have to ask where is the main place that should have been changed? Was it this?
