### PR TITLE
feat(ui): Add hover shortcuts and global shortcuts

### DIFF
--- a/packages/ui/src/Editor.tsx
+++ b/packages/ui/src/Editor.tsx
@@ -25,8 +25,12 @@ export function Editor() {
           end={<Viewport />}
         />
       }
-      end={<Timeline />}
-      footer={<Footer />}
+      end={
+        <div>
+          <Timeline />
+          <Footer />
+        </div>
+      }
     />
   ) : (
     <PresentationMode />

--- a/packages/ui/src/Editor.tsx
+++ b/packages/ui/src/Editor.tsx
@@ -26,10 +26,10 @@ export function Editor() {
         />
       }
       end={
-        <div>
+        <>
           <Timeline />
           <Footer />
-        </div>
+        </>
       }
     />
   ) : (

--- a/packages/ui/src/Editor.tsx
+++ b/packages/ui/src/Editor.tsx
@@ -1,5 +1,6 @@
 import {Sidebar} from './components/sidebar';
 import {Timeline} from './components/timeline';
+import {Footer} from './components/footer';
 import {Viewport} from './components/viewport';
 import {ResizeableLayout} from './components/layout';
 import {useState} from 'preact/hooks';
@@ -25,6 +26,7 @@ export function Editor() {
         />
       }
       end={<Timeline />}
+      footer={<Footer />}
     />
   ) : (
     <PresentationMode />

--- a/packages/ui/src/components/footer/Footer.module.scss
+++ b/packages/ui/src/components/footer/Footer.module.scss
@@ -1,0 +1,26 @@
+.root {
+  display: flex;
+  flex-direction: row;
+  padding: 8px;
+  overflow-x: hidden;
+  height: 32px;
+}
+.action {
+  height: 32px;
+}
+
+.key {
+  border: 1px solid var(--blue);
+  border-radius: 4px;
+  margin-right: 4px;
+  padding: 2px 4px;
+}
+
+.separator {
+  color: var(--surface-color-light);
+  padding: 0px 4px;
+}
+
+.shortcut {
+  flex: none;
+}

--- a/packages/ui/src/components/footer/Footer.module.scss
+++ b/packages/ui/src/components/footer/Footer.module.scss
@@ -1,6 +1,10 @@
 .root {
   display: flex;
-  padding: 4px;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  height: 1.5rem;
+  padding: 1px 4px;
   overflow-x: hidden;
 }
 

--- a/packages/ui/src/components/footer/Footer.module.scss
+++ b/packages/ui/src/components/footer/Footer.module.scss
@@ -1,26 +1,26 @@
 .root {
   display: flex;
-  flex-direction: row;
-  padding: 8px;
+  padding: 4px;
   overflow-x: hidden;
-  height: 32px;
-}
-.action {
-  height: 32px;
-}
-
-.key {
-  border: 1px solid var(--blue);
-  border-radius: 4px;
-  margin-right: 4px;
-  padding: 2px 4px;
-}
-
-.separator {
-  color: var(--surface-color-light);
-  padding: 0px 4px;
 }
 
 .shortcut {
-  flex: none;
+  &:not(:last-child) {
+    border-right: 2px solid var(--surface-color);
+    padding-right: 8px;
+    margin-right: 8px;
+  }
+}
+
+.action {
+  font-size: 12px;
+}
+
+.key {
+  background-color: var(--surface-color-hover);
+  font-weight: bold;
+  border-radius: 4px;
+  margin-right: 4px;
+  padding: 0 4px;
+  font-size: 12px;
 }

--- a/packages/ui/src/components/footer/Footer.module.scss
+++ b/packages/ui/src/components/footer/Footer.module.scss
@@ -14,17 +14,15 @@
     padding-right: 8px;
     margin-right: 8px;
   }
-}
-
-.action {
-  font-size: 12px;
-}
-
-.key {
-  background-color: var(--surface-color-hover);
-  font-weight: bold;
-  border-radius: 4px;
-  margin-right: 4px;
-  padding: 0 4px;
-  font-size: 12px;
+  .key {
+    background-color: var(--surface-color-hover);
+    font-weight: bold;
+    border-radius: 4px;
+    margin-right: 4px;
+    padding: 0 4px;
+    font-size: 12px;
+  }
+  .action {
+    font-size: 12px;
+  }
 }

--- a/packages/ui/src/components/footer/Footer.tsx
+++ b/packages/ui/src/components/footer/Footer.tsx
@@ -1,0 +1,21 @@
+import {useShortcuts} from '../../contexts/shortcuts';
+import styles from './Footer.module.scss';
+
+export function Footer() {
+  const {shortcuts, currentModule} = useShortcuts();
+  return (
+    <div className={styles.root}>
+      {shortcuts[currentModule].map(({key, action, isGlobal}, index, arr) =>
+        isGlobal ? null : (
+          <div className={styles.shortcut}>
+            <span className={styles.key}>{key}</span>
+            <span className={styles.action}>{action}</span>
+            {index < arr.length - 1 && (
+              <span className={styles.separator}>|</span>
+            )}
+          </div>
+        ),
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/footer/Footer.tsx
+++ b/packages/ui/src/components/footer/Footer.tsx
@@ -5,11 +5,10 @@ export function Footer() {
   const {shortcuts, currentModule} = useShortcuts();
   return (
     <div className={styles.root}>
-      {shortcuts[currentModule].map(({key, action}, index, arr) => (
-        <div>
+      {shortcuts[currentModule].map(({key, action}) => (
+        <div className={styles.shortcut}>
           <span className={styles.key}>{key}</span>
           <span className={styles.action}>{action}</span>
-          {index < arr.length - 1}
         </div>
       ))}
     </div>

--- a/packages/ui/src/components/footer/Footer.tsx
+++ b/packages/ui/src/components/footer/Footer.tsx
@@ -5,17 +5,13 @@ export function Footer() {
   const {shortcuts, currentModule} = useShortcuts();
   return (
     <div className={styles.root}>
-      {shortcuts[currentModule].map(({key, action, isGlobal}, index, arr) =>
-        isGlobal ? null : (
-          <div className={styles.shortcut}>
-            <span className={styles.key}>{key}</span>
-            <span className={styles.action}>{action}</span>
-            {index < arr.length - 1 && (
-              <span className={styles.separator}>|</span>
-            )}
-          </div>
-        ),
-      )}
+      {shortcuts[currentModule].map(({key, action}, index, arr) => (
+        <div>
+          <span className={styles.key}>{key}</span>
+          <span className={styles.action}>{action}</span>
+          {index < arr.length - 1}
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/ui/src/components/footer/index.ts
+++ b/packages/ui/src/components/footer/index.ts
@@ -1,0 +1,1 @@
+export * from './Footer';

--- a/packages/ui/src/components/layout/ResizeableLayout.tsx
+++ b/packages/ui/src/components/layout/ResizeableLayout.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx';
 interface ResizeableLayoutProps {
   start: ComponentChild;
   end: ComponentChild;
-  footer: ComponentChild;
   vertical?: boolean;
   size?: number;
   id?: string;
@@ -18,7 +17,6 @@ interface ResizeableLayoutProps {
 export function ResizeableLayout({
   start,
   end,
-  footer,
   vertical = false,
   size = 0.3,
   id = null,
@@ -59,7 +57,6 @@ export function ResizeableLayout({
       </div>
       <div onMouseDown={handleDrag} className={styles.separator} />
       <div className={styles.right}>{end}</div>
-      <div className={styles.right}>{footer}</div>
     </div>
   );
 }

--- a/packages/ui/src/components/layout/ResizeableLayout.tsx
+++ b/packages/ui/src/components/layout/ResizeableLayout.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 interface ResizeableLayoutProps {
   start: ComponentChild;
   end: ComponentChild;
+  footer: ComponentChild;
   vertical?: boolean;
   size?: number;
   id?: string;
@@ -17,6 +18,7 @@ interface ResizeableLayoutProps {
 export function ResizeableLayout({
   start,
   end,
+  footer,
   vertical = false,
   size = 0.3,
   id = null,
@@ -57,6 +59,7 @@ export function ResizeableLayout({
       </div>
       <div onMouseDown={handleDrag} className={styles.separator} />
       <div className={styles.right}>{end}</div>
+      <div className={styles.right}>{footer}</div>
     </div>
   );
 }

--- a/packages/ui/src/components/timeline/Timeline.module.scss
+++ b/packages/ui/src/components/timeline/Timeline.module.scss
@@ -3,6 +3,7 @@
   width: 100%;
   height: 100%;
   padding-top: 1px;
+  padding-bottom: 1.5rem;
   opacity: 0;
   transition: opacity 0.2s;
   display: flex;

--- a/packages/ui/src/components/timeline/Timeline.tsx
+++ b/packages/ui/src/components/timeline/Timeline.tsx
@@ -22,6 +22,7 @@ import {
   TimelineState,
 } from '../../contexts';
 import clsx from 'clsx';
+import {useShortcut} from '../../hooks/useShortcut';
 
 const ZOOM_SPEED = 0.1;
 const ZOOM_MIN = 0.5;
@@ -29,6 +30,7 @@ const TIMESTAMP_SPACING = 32;
 const MAX_FRAME_SIZE = 128;
 
 export function Timeline() {
+  const [hoverRef] = useShortcut<HTMLDivElement>('timeline');
   const {player} = useApplication();
   const containerRef = useRef<HTMLDivElement>();
   const playheadRef = useRef<HTMLDivElement>();
@@ -135,7 +137,7 @@ export function Timeline() {
 
   return (
     <TimelineContextProvider state={state}>
-      <div className={clsx(styles.root, isReady && styles.show)}>
+      <div ref={hoverRef} className={clsx(styles.root, isReady && styles.show)}>
         <div
           className={styles.timelineWrapper}
           ref={containerRef}

--- a/packages/ui/src/components/viewport/Viewport.tsx
+++ b/packages/ui/src/components/viewport/Viewport.tsx
@@ -6,15 +6,17 @@ import styles from './Viewport.module.scss';
 import {useApplication} from '../../contexts';
 import {CustomStage} from './CustomStage';
 import {RendererState} from '@motion-canvas/core';
+import {useShortcut} from '../../hooks/useShortcut';
 
 export function Viewport() {
+  const [hoverRef] = useShortcut<HTMLDivElement>('viewport');
   const {player, renderer} = useApplication();
   const duration = useDuration();
   const {speed} = usePlayerState();
   const state = useRendererState();
 
   return (
-    <div className={styles.root}>
+    <div ref={hoverRef} className={styles.root}>
       {state === RendererState.Working ? (
         <CustomStage stage={renderer.stage} />
       ) : (

--- a/packages/ui/src/contexts/shortcuts.tsx
+++ b/packages/ui/src/contexts/shortcuts.tsx
@@ -14,7 +14,7 @@ type ShortcutsState = {
   setCurrentModule?: (module: ShortcutModules) => void;
 };
 
-const initialshortcuts: ShortcutsByModule = {
+const InitialShortcuts: ShortcutsByModule = {
   global: [
     {key: 'Space', action: 'Toggle playback'},
     {key: '<-', action: 'Previous frame'},
@@ -36,7 +36,7 @@ const initialshortcuts: ShortcutsByModule = {
 
 const ShortcutsContext = createContext<ShortcutsState>({
   currentModule: 'none',
-  shortcuts: initialshortcuts,
+  shortcuts: InitialShortcuts,
 });
 
 export function ShortcutsProvider({children}: {children: ComponentChildren}) {
@@ -44,7 +44,7 @@ export function ShortcutsProvider({children}: {children: ComponentChildren}) {
 
   return (
     <ShortcutsContext.Provider
-      value={{currentModule, setCurrentModule, shortcuts: initialshortcuts}}
+      value={{currentModule, setCurrentModule, shortcuts: InitialShortcuts}}
     >
       {children}
     </ShortcutsContext.Provider>

--- a/packages/ui/src/contexts/shortcuts.tsx
+++ b/packages/ui/src/contexts/shortcuts.tsx
@@ -4,10 +4,9 @@ import {useContext, useState} from 'preact/hooks';
 export type Shortcut = {
   key: string;
   action: string;
-  isGlobal?: boolean;
 };
 
-export type ShortcutModules = 'global' | 'timeline' | 'none';
+export type ShortcutModules = 'global' | 'timeline' | 'viewport' | 'none';
 type ShortcutsByModule = Record<ShortcutModules, Shortcut[]>;
 type ShortcutsState = {
   currentModule: ShortcutModules;
@@ -17,15 +16,21 @@ type ShortcutsState = {
 
 const initialshortcuts: ShortcutsByModule = {
   global: [
-    {key: 'Space', action: 'Toggle playback', isGlobal: true},
-    {key: '←', action: 'Previous frame', isGlobal: true},
-    {key: '→', action: 'Next frame', isGlobal: true},
-    {key: 'Shift + ←', action: 'Reset to first frame', isGlobal: true},
-    {key: 'Shift + →', action: 'Seek to last frame', isGlobal: true},
-    {key: 'm', action: 'Toggle audio', isGlobal: true},
-    {key: 'l', action: 'Toggle loop', isGlobal: true},
+    {key: 'Space', action: 'Toggle playback'},
+    {key: '<-', action: 'Previous frame'},
+    {key: '->', action: 'Next frame'},
+    {key: 'Shift + <-', action: 'Reset to first frame'},
+    {key: 'Shift + ->', action: 'Seek to last frame'},
+    {key: 'M', action: 'Toggle audio'},
+    {key: 'L', action: 'Toggle loop'},
   ],
-  timeline: [{key: 'f', action: 'Focus Playhead'}],
+  viewport: [
+    {key: '0', action: 'Reset zoom'},
+    {key: '=', action: 'Zoom in'},
+    {key: '-', action: 'Zoom out'},
+    {key: "'", action: 'Toggle grid'},
+  ],
+  timeline: [{key: 'F', action: 'Focus playhead'}],
   none: [],
 };
 

--- a/packages/ui/src/contexts/shortcuts.tsx
+++ b/packages/ui/src/contexts/shortcuts.tsx
@@ -1,0 +1,51 @@
+import {ComponentChildren, createContext} from 'preact';
+import {useContext, useState} from 'preact/hooks';
+
+export type Shortcut = {
+  key: string;
+  action: string;
+  isGlobal?: boolean;
+};
+
+export type ShortcutModules = 'global' | 'timeline' | 'none';
+type ShortcutsByModule = Record<ShortcutModules, Shortcut[]>;
+type ShortcutsState = {
+  currentModule: ShortcutModules;
+  shortcuts: ShortcutsByModule;
+  setCurrentModule?: (module: ShortcutModules) => void;
+};
+
+const initialshortcuts: ShortcutsByModule = {
+  global: [
+    {key: 'Space', action: 'Toggle playback', isGlobal: true},
+    {key: '←', action: 'Previous frame', isGlobal: true},
+    {key: '→', action: 'Next frame', isGlobal: true},
+    {key: 'Shift + ←', action: 'Reset to first frame', isGlobal: true},
+    {key: 'Shift + →', action: 'Seek to last frame', isGlobal: true},
+    {key: 'm', action: 'Toggle audio', isGlobal: true},
+    {key: 'l', action: 'Toggle loop', isGlobal: true},
+  ],
+  timeline: [{key: 'f', action: 'Focus Playhead'}],
+  none: [],
+};
+
+const ShortcutsContext = createContext<ShortcutsState>({
+  currentModule: 'none',
+  shortcuts: initialshortcuts,
+});
+
+export function ShortcutsProvider({children}: {children: ComponentChildren}) {
+  const [currentModule, setCurrentModule] = useState<ShortcutModules>('none');
+
+  return (
+    <ShortcutsContext.Provider
+      value={{currentModule, setCurrentModule, shortcuts: initialshortcuts}}
+    >
+      {children}
+    </ShortcutsContext.Provider>
+  );
+}
+
+export function useShortcuts() {
+  return useContext(ShortcutsContext);
+}

--- a/packages/ui/src/hooks/useHover.ts
+++ b/packages/ui/src/hooks/useHover.ts
@@ -10,12 +10,12 @@ export function useHover<T extends HTMLElement>(
 
   const ref = useRef<T>(null);
 
-  const _handleMouseOver = () => {
+  const handleMouseOverWrapper = () => {
     setValue(true);
     handleMouseOver?.();
   };
 
-  const _handleMouseOut = () => {
+  const handleMouseOutWrapper = () => {
     setValue(false);
     handleMouseOut?.();
   };
@@ -24,12 +24,12 @@ export function useHover<T extends HTMLElement>(
     () => {
       const node = ref.current;
       if (node) {
-        node.addEventListener('mouseover', _handleMouseOver);
-        node.addEventListener('mouseout', _handleMouseOut);
+        node.addEventListener('mouseover', handleMouseOverWrapper);
+        node.addEventListener('mouseout', handleMouseOutWrapper);
 
         return () => {
-          node.removeEventListener('mouseover', _handleMouseOver);
-          node.removeEventListener('mouseout', _handleMouseOut);
+          node.removeEventListener('mouseover', handleMouseOverWrapper);
+          node.removeEventListener('mouseout', handleMouseOutWrapper);
         };
       }
     },

--- a/packages/ui/src/hooks/useHover.ts
+++ b/packages/ui/src/hooks/useHover.ts
@@ -1,0 +1,40 @@
+import React, {useEffect, useRef, useState} from 'react';
+
+type UseHoverType<T extends HTMLElement> = [React.RefObject<T>, boolean];
+
+export function useHover<T extends HTMLElement>(
+  handleMouseOver?: () => void,
+  handleMouseOut?: () => void,
+): UseHoverType<T> {
+  const [value, setValue] = useState(false);
+
+  const ref = useRef<T>(null);
+
+  const _handleMouseOver = () => {
+    setValue(true);
+    handleMouseOver?.();
+  };
+
+  const _handleMouseOut = () => {
+    setValue(false);
+    handleMouseOut?.();
+  };
+
+  useEffect(
+    () => {
+      const node = ref.current;
+      if (node) {
+        node.addEventListener('mouseover', _handleMouseOver);
+        node.addEventListener('mouseout', _handleMouseOut);
+
+        return () => {
+          node.removeEventListener('mouseover', _handleMouseOver);
+          node.removeEventListener('mouseout', _handleMouseOut);
+        };
+      }
+    },
+    [ref.current], // Recall only if ref changes
+  );
+
+  return [ref, value];
+}

--- a/packages/ui/src/hooks/useShortcut.ts
+++ b/packages/ui/src/hooks/useShortcut.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import {useShortcuts, ShortcutModules} from '../contexts/shortcuts';
+import {useHover} from './useHover';
+
+type UseHoverType<T extends HTMLElement> = [React.RefObject<T>, boolean];
+
+export function useShortcut<T extends HTMLElement>(
+  shortcutModule: ShortcutModules,
+): UseHoverType<T> {
+  const {setCurrentModule} = useShortcuts();
+  const [ref, value] = useHover<T>(
+    () => {
+      setCurrentModule(shortcutModule);
+    },
+    () => {
+      setCurrentModule('none');
+    },
+  );
+
+  return [ref, value];
+}

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -11,6 +11,7 @@ import {
   ApplicationProvider,
 } from './contexts';
 import {getItem, setItem} from './utils';
+import {ShortcutsProvider} from './contexts/shortcuts';
 
 function renderRoot(vnode: ComponentChild) {
   const root = document.createElement('main');
@@ -67,11 +68,13 @@ export function editor(project: Project) {
         meta,
       }}
     >
-      <LoggerProvider>
-        <InspectionProvider>
-          <Editor />
-        </InspectionProvider>
-      </LoggerProvider>
+      <ShortcutsProvider>
+        <LoggerProvider>
+          <InspectionProvider>
+            <Editor />
+          </InspectionProvider>
+        </LoggerProvider>
+      </ShortcutsProvider>
     </ApplicationProvider>,
   );
 }


### PR DESCRIPTION
# Shortcuts hovers

Now if you hover some of the components that have shortcut a small preview of the shortcuts will be displayed on the footer:

![HoverGifExample](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMjUxMThjOWE0NDkyZDAwZWMxMGUxNTJmOGNjNmQxOTdlNjdmNmIxZSZjdD1n/TKhbuSIItaivyERDHb/giphy.gif)

## Changes:

- Add footer component  to display the shortcuts here
- useHover hook added
- useShorcut hook added - to fetch the shortcut context
- ShortcutProvider to store all the shortcuts and change the current module that it is hover
- Added example use of the shortcut hook for the Timeline component
- Added shortcuts for Viewport
