### PR TITLE
refactor(core): use relative time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21534,7 +21534,7 @@
     },
     "packages/2d": {
       "name": "@motion-canvas/2d",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@motion-canvas/core": "^3.0.0",
@@ -21572,7 +21572,7 @@
     },
     "packages/create": {
       "name": "@motion-canvas/create",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -21581,7 +21581,7 @@
         "create-motion-canvas": "index.js"
       },
       "devDependencies": {
-        "@motion-canvas/2d": "^3.0.0",
+        "@motion-canvas/2d": "^3.0.2",
         "@motion-canvas/core": "^3.0.0",
         "@motion-canvas/ui": "^3.0.1",
         "@motion-canvas/vite-plugin": "^3.0.0"
@@ -24959,7 +24959,7 @@
     "@motion-canvas/create": {
       "version": "file:packages/create",
       "requires": {
-        "@motion-canvas/2d": "^3.0.0",
+        "@motion-canvas/2d": "^3.0.2",
         "@motion-canvas/core": "^3.0.0",
         "@motion-canvas/ui": "^3.0.1",
         "@motion-canvas/vite-plugin": "^3.0.0",

--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -12,6 +12,7 @@ import {Scene} from '../scenes';
 import {Vector2} from '../types';
 import {PlaybackStatus} from './PlaybackStatus';
 import {Semaphore} from '../utils';
+import {EditableTimeEvents} from '../scenes/timeEvents';
 
 export interface PlayerState extends Record<string, unknown> {
   paused: boolean;
@@ -151,6 +152,7 @@ export class Player {
         playback: this.status,
         logger: this.project.logger,
         size: this.size,
+        timeEventsClass: EditableTimeEvents,
       });
       description.onReplaced?.subscribe(description => {
         scene.reload(description);

--- a/packages/core/src/app/Renderer.ts
+++ b/packages/core/src/app/Renderer.ts
@@ -8,6 +8,7 @@ import {Exporter} from './Exporter';
 import {CanvasOutputMimeType, Vector2} from '../types';
 import {PlaybackStatus} from './PlaybackStatus';
 import {Semaphore} from '../utils';
+import {ReadOnlyTimeEvents} from '../scenes/timeEvents';
 
 export interface RendererSettings extends StageSettings {
   name: string;
@@ -75,6 +76,7 @@ export class Renderer {
         logger: this.project.logger,
         playback: this.status,
         size: new Vector2(1920, 1080),
+        timeEventsClass: ReadOnlyTimeEvents,
       });
       scenes.push(scene);
     }

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -6,7 +6,7 @@ import {
   threads,
 } from '../threading';
 import {Logger, PlaybackStatus} from '../app';
-import {TimeEvents} from './TimeEvents';
+import {TimeEvents} from './timeEvents';
 import {Variables} from './Variables';
 import {EventDispatcher, ValueDispatcher} from '../events';
 import {decorate, threadable} from '../decorators';
@@ -125,7 +125,7 @@ export abstract class GeneratorScene<T>
     this.creationStack = description.stack;
 
     decorate(this.runnerFactory, threadable(this.name));
-    this.timeEvents = new TimeEvents(this);
+    this.timeEvents = new description.timeEventsClass(this);
     this.variables = new Variables(this);
 
     this.random = new Random(this.meta.seed.get());
@@ -264,12 +264,6 @@ export abstract class GeneratorScene<T>
   }
 
   public async reset(previousScene: Scene | null = null) {
-    if (this.cache.current.firstFrame !== this.playback.frame) {
-      this.cache.current = {
-        ...this.cache.current,
-        firstFrame: this.playback.frame,
-      };
-    }
     this.counters = {};
     this.previousScene = previousScene;
     this.random = new Random(this.meta.seed.get());

--- a/packages/core/src/scenes/Scene.ts
+++ b/packages/core/src/scenes/Scene.ts
@@ -1,15 +1,15 @@
-import {Logger, PlaybackStatus} from '../app';
-import {TimeEvents} from './TimeEvents';
-import {Variables} from './Variables';
-import {
+import type {Logger, PlaybackStatus} from '../app';
+import type {TimeEvents} from './timeEvents';
+import type {Variables} from './Variables';
+import type {
   SubscribableEvent,
   SubscribableValueEvent,
   ValueDispatcher,
 } from '../events';
-import {Vector2} from '../types';
-import {LifecycleEvents} from './LifecycleEvents';
-import {Random} from './Random';
-import {SceneMetadata} from './SceneMetadata';
+import type {Vector2} from '../types';
+import type {LifecycleEvents} from './LifecycleEvents';
+import type {Random} from './Random';
+import type {SceneMetadata} from './SceneMetadata';
 
 /**
  * The constructor used when creating new scenes.
@@ -59,6 +59,7 @@ export interface FullSceneDescription<T = unknown> extends SceneDescription<T> {
   playback: PlaybackStatus;
   logger: Logger;
   onReplaced: ValueDispatcher<FullSceneDescription<T>>;
+  timeEventsClass: new (scene: Scene) => TimeEvents;
 }
 
 /**

--- a/packages/core/src/scenes/SceneMetadata.ts
+++ b/packages/core/src/scenes/SceneMetadata.ts
@@ -1,5 +1,5 @@
 import {MetaField, ObjectMetaField} from '../meta';
-import {SavedTimeEvent} from './TimeEvents';
+import {SerializedTimeEvent} from './timeEvents';
 import {Random} from './Random';
 
 /**
@@ -8,7 +8,7 @@ import {Random} from './Random';
 export function createSceneMetadata() {
   return new ObjectMetaField('scene', {
     version: new MetaField('version', 1),
-    timeEvents: new MetaField<SavedTimeEvent[]>('time events', []),
+    timeEvents: new MetaField<SerializedTimeEvent[]>('time events', []),
     seed: new MetaField('seed', Random.createSeed()),
   });
 }

--- a/packages/core/src/scenes/index.ts
+++ b/packages/core/src/scenes/index.ts
@@ -11,6 +11,5 @@ export * from './Scene';
 export * from './SceneMetadata';
 export * from './SceneState';
 export * from './Threadable';
-export * from './TimeEvents';
 export * from './Variables';
 export * from './LifecycleEvents';

--- a/packages/core/src/scenes/timeEvents/ReadOnlyTimeEvents.ts
+++ b/packages/core/src/scenes/timeEvents/ReadOnlyTimeEvents.ts
@@ -1,0 +1,44 @@
+import type {Scene} from '../Scene';
+import type {TimeEvent} from './TimeEvent';
+import type {TimeEvents} from './TimeEvents';
+import {ValueDispatcher} from '../../events';
+import {useThread} from '../../utils';
+
+/**
+ * Manages time events during rendering and presentation.
+ */
+export class ReadOnlyTimeEvents implements TimeEvents {
+  public get onChanged() {
+    return this.events.subscribable;
+  }
+  private readonly events = new ValueDispatcher<TimeEvent[]>([]);
+  private lookup = new Map<string, number>();
+
+  public constructor(private readonly scene: Scene) {
+    scene.onReloaded.subscribe(this.handleReload);
+  }
+
+  public set() {
+    // do nothing
+  }
+
+  public register(name: string): number {
+    let duration = this.lookup.get(name);
+    if (duration === undefined) {
+      const event = this.scene.meta.timeEvents
+        .get()
+        .find(event => event.name === name);
+      duration = event ? event.targetTime - useThread().time() : 0;
+      this.lookup.set(name, duration);
+    }
+
+    return duration;
+  }
+
+  /**
+   * Called when the parent scene gets reloaded.
+   */
+  private handleReload = () => {
+    this.lookup.clear();
+  };
+}

--- a/packages/core/src/scenes/timeEvents/SerializedTimeEvent.ts
+++ b/packages/core/src/scenes/timeEvents/SerializedTimeEvent.ts
@@ -1,0 +1,13 @@
+/**
+ * Represents a time event stored in a meta file.
+ */
+export interface SerializedTimeEvent {
+  /**
+   * {@inheritDoc TimeEvent.name}
+   */
+  name: string;
+  /**
+   * {@inheritDoc TimeEvent.targetTime}
+   */
+  targetTime: number;
+}

--- a/packages/core/src/scenes/timeEvents/TimeEvent.ts
+++ b/packages/core/src/scenes/timeEvents/TimeEvent.ts
@@ -1,0 +1,31 @@
+/**
+ * Represents a time event at runtime.
+ */
+export interface TimeEvent {
+  /**
+   * Name of the event.
+   */
+  name: string;
+  /**
+   * Time in seconds, relative to the beginning of the scene, at which the event
+   * was registered.
+   *
+   * @remarks
+   * In other words, the moment at which {@link flow.waitUntil} for this event
+   * was invoked.
+   */
+  initialTime: number;
+  /**
+   * Time in seconds, relative to the beginning of the scene, at which the event
+   * should end.
+   */
+  targetTime: number;
+  /**
+   * Duration of the event in seconds.
+   */
+  offset: number;
+  /**
+   * Stack trace at the moment of registration.
+   */
+  stack?: string;
+}

--- a/packages/core/src/scenes/timeEvents/TimeEvents.ts
+++ b/packages/core/src/scenes/timeEvents/TimeEvents.ts
@@ -1,0 +1,34 @@
+import type {SubscribableValueEvent} from '../../events';
+import type {TimeEvent} from './TimeEvent';
+
+/**
+ * An interface for classes managing the time events.
+ */
+export interface TimeEvents {
+  /**
+   * Triggered when time events change.
+   *
+   * @eventProperty
+   */
+  get onChanged(): SubscribableValueEvent<TimeEvent[]>;
+  /**
+   * Change the time offset of the given event.
+   *
+   * @param name - The name of the event.
+   * @param offset - The time offset in seconds.
+   * @param preserve - Whether the timing of the consecutive events should be
+   *                   preserved. When set to `true` their offsets will be
+   *                   adjusted to keep them in place.
+   */
+  set(name: string, offset: number, preserve?: boolean): void;
+  /**
+   * Register a time event.
+   *
+   * @param name - The name of the event.
+   *
+   * @returns The duration of the event in seconds.
+   *
+   * @internal
+   */
+  register(name: string): number;
+}

--- a/packages/core/src/scenes/timeEvents/index.ts
+++ b/packages/core/src/scenes/timeEvents/index.ts
@@ -1,0 +1,5 @@
+export * from './EditableTimeEvents';
+export * from './ReadOnlyTimeEvents';
+export * from './SerializedTimeEvent';
+export * from './TimeEvent';
+export * from './TimeEvents';

--- a/packages/core/src/threading/Thread.ts
+++ b/packages/core/src/threading/Thread.ts
@@ -1,5 +1,5 @@
 import {ThreadGenerator} from './ThreadGenerator';
-import {endThread, startThread, usePlayback} from '../utils';
+import {endThread, startThread} from '../utils';
 import {createSignal} from '../signals';
 import {setTaskName} from './names';
 
@@ -29,6 +29,18 @@ export class Thread {
   public readonly time = createSignal(0);
 
   /**
+   * The fixed time of this thread.
+   *
+   * @remarks
+   * Fixed time is a multiple of the frame duration. It can be used to account
+   * for the difference between this thread's {@link time} and the time of the
+   * current animation frame.
+   */
+  public get fixed() {
+    return this.fixedTime;
+  }
+
+  /**
    * Check if this thread or any of its ancestors has been canceled.
    */
   public get canceled(): boolean {
@@ -37,18 +49,14 @@ export class Thread {
 
   public parent: Thread | null = null;
   private isCanceled = false;
-  private readonly frameDuration: number;
+  private fixedTime = 0;
 
   public constructor(
     /**
      * The generator wrapped by this thread.
      */
     public readonly runner: ThreadGenerator,
-  ) {
-    const playback = usePlayback();
-    this.frameDuration = playback.framesToSeconds(1);
-    this.time(playback.time);
-  }
+  ) {}
 
   /**
    * Progress the wrapped generator once.
@@ -63,10 +71,12 @@ export class Thread {
 
   /**
    * Prepare the thread for the next update cycle.
+   *
+   * @param dt - The delta time of the next cycle.
    */
-  public update() {
-    const playback = usePlayback();
-    this.time(this.time() + playback.framesToSeconds(1) * playback.speed);
+  public update(dt: number) {
+    this.time(this.time() + dt);
+    this.fixedTime += dt;
     this.children = this.children.filter(child => !child.canceled);
   }
 

--- a/packages/core/src/threading/threads.ts
+++ b/packages/core/src/threading/threads.ts
@@ -2,6 +2,7 @@ import {decorate, threadable} from '../decorators';
 import {Thread} from './Thread';
 import {isThreadGenerator, ThreadGenerator} from './ThreadGenerator';
 import {setTaskName} from './names';
+import {usePlayback} from '../utils';
 
 /**
  * Check if the given value is a [Promise][promise].
@@ -55,6 +56,7 @@ export function* threads(
   factory: ThreadsFactory,
   callback?: ThreadsCallback,
 ): ThreadGenerator {
+  const playback = usePlayback();
   const root = factory();
   setTaskName(root, 'root');
   const rootThread = new Thread(root);
@@ -64,6 +66,7 @@ export function* threads(
   while (threads.length > 0) {
     const newThreads = [];
     const queue = [...threads];
+    const dt = playback.framesToSeconds(1) * playback.speed;
 
     while (queue.length > 0) {
       const thread = queue.pop();
@@ -88,7 +91,7 @@ export function* threads(
         thread.value = yield result.value;
         queue.push(thread);
       } else {
-        thread.update();
+        thread.update(dt);
         newThreads.unshift(thread);
       }
     }

--- a/packages/core/src/tweening/spring.ts
+++ b/packages/core/src/tweening/spring.ts
@@ -1,6 +1,6 @@
 import {decorate, threadable} from '../decorators';
 import {ThreadGenerator} from '../threading';
-import {usePlayback, useThread, useLogger} from '../utils';
+import {useThread, useLogger} from '../utils';
 
 type ProgressFunction = (value: number, time: number) => void;
 
@@ -69,7 +69,6 @@ export function* spring(
     return;
   }
 
-  const project = usePlayback();
   const thread = useThread();
 
   let position = from;
@@ -104,12 +103,12 @@ export function* spring(
 
   let settled = false;
   while (!settled) {
-    while (simulationTime < project.time) {
-      const difference = project.time - simulationTime;
+    while (simulationTime < thread.fixed) {
+      const difference = thread.fixed - simulationTime;
 
       if (timeStep > difference) {
         update(difference);
-        simulationTime = project.time;
+        simulationTime = thread.fixed;
       } else {
         update(timeStep);
         simulationTime += timeStep;
@@ -130,13 +129,13 @@ export function* spring(
 
     // Only yield if we haven't settled yet.
     if (!settled) {
-      onProgress(position, project.time - startTime);
+      onProgress(position, thread.fixed - startTime);
       yield;
     }
   }
 
-  onProgress(to, project.time - startTime);
-  onEnd?.(to, project.time - startTime);
+  onProgress(to, thread.fixed - startTime);
+  onEnd?.(to, thread.fixed - startTime);
 }
 
 export interface Spring {

--- a/packages/core/src/tweening/tween.ts
+++ b/packages/core/src/tweening/tween.ts
@@ -1,6 +1,6 @@
 import {decorate, threadable} from '../decorators';
 import {ThreadGenerator} from '../threading';
-import {usePlayback, useThread} from '../utils';
+import {useThread} from '../utils';
 
 decorate(tween, threadable());
 export function* tween(
@@ -8,15 +8,14 @@ export function* tween(
   onProgress: (value: number, time: number) => void,
   onEnd?: (value: number, time: number) => void,
 ): ThreadGenerator {
-  const project = usePlayback();
   const thread = useThread();
 
   const startTime = thread.time();
   const endTime = thread.time() + seconds;
 
   onProgress(0, 0);
-  while (endTime > project.time) {
-    const time = project.time - startTime;
+  while (endTime > thread.fixed) {
+    const time = thread.fixed - startTime;
     const value = time / seconds;
     if (time > 0) {
       onProgress(value, time);

--- a/packages/core/src/utils/useDuration.ts
+++ b/packages/core/src/utils/useDuration.ts
@@ -26,6 +26,5 @@ import {useScene} from './useScene';
  */
 export function useDuration(name: string): number {
   const scene = useScene();
-  scene.timeEvents.register(name);
-  return scene.timeEvents.get(name).offset;
+  return scene.timeEvents.register(name);
 }

--- a/packages/ui/src/components/timeline/Label.tsx
+++ b/packages/ui/src/components/timeline/Label.tsx
@@ -1,6 +1,7 @@
 import styles from './Timeline.module.scss';
 
-import type {Scene, TimeEvent} from '@motion-canvas/core/lib/scenes';
+import type {Scene} from '@motion-canvas/core/lib/scenes';
+import type {TimeEvent} from '@motion-canvas/core/lib/scenes/timeEvents';
 import {useDrag} from '../../hooks';
 import {useCallback, useLayoutEffect, useState} from 'preact/hooks';
 import {useApplication, useTimelineContext} from '../../contexts';


### PR DESCRIPTION
Time is now always expressed relative to the beginning of the scene.