### PR TITLE
docs: use correct return type for flicker function

### DIFF
--- a/packages/docs/docs/getting-started/flow.mdx
+++ b/packages/docs/docs/getting-started/flow.mdx
@@ -62,6 +62,8 @@ For instance, we could extract the flickering code from the above example to a
 separate generator and delegate our scene function to it:
 
 ```tsx
+import {ThreadGenerator} from '@motion-canvas/core/lib/threading';
+
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();
   view.add(<Circle ref={circle} width={100} height={100} />);
@@ -69,7 +71,7 @@ export default makeScene2D(function* (view) {
   yield* flicker(circle());
 });
 
-function* flicker(circle: Circle): Generator {
+function* flicker(circle: Circle): ThreadGenerator {
   circle.fill('red');
   yield;
   circle.fill('blue');


### PR DESCRIPTION
My original PR (#266) added the a `Generator` return type to the `flicker` function in the docs to get rid of a Typescript error.  Turns out that this just added a different error because the runner function of the scene expects a `ThreadGeneratorFactory`. 

This has come up a few times already in the Discord as a source of confusion.