### PR TITLE
docs: correct import for CodeBlock (#464)

### DIFF
--- a/packages/docs/docs/components/code-block.mdx
+++ b/packages/docs/docs/components/code-block.mdx
@@ -22,7 +22,7 @@ important snippets.
 To display code, set the `code` and `language` property.
 
 ```ts
-import {CodeBlock} from '@motion-canvas/2d/lib/components';
+import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
 
 yield view.add(
   <CodeBlock language="c#" code={`Console.WriteLine("Hello World!")`} />,
@@ -48,7 +48,7 @@ For convenience, the indentation of code will be automatically adjust whenever
 the code starts with a new line.
 
 ```tsx
-import {CodeBlock} from '@motion-canvas/2d/lib/components';
+import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
 
 yield view.add(
   // note that the ` bracket is followed by a new line
@@ -71,7 +71,7 @@ console.log('Hello World!');
 The indentation is then set by the least indented code.
 
 ```tsx
-import {CodeBlock} from '@motion-canvas/2d/lib/components';
+import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
 
 yield view.add(
   // note that the ` bracket is followed by a new line
@@ -131,7 +131,7 @@ line, starting at the fifth character, and selecting a total of six characters.
 Finally, you can use the `lines` function to select whole lines of code.
 
 ```tsx
-import {CodeBlock, lines} from '@motion-canvas/2d/lib/components';
+import {CodeBlock, lines} from '@motion-canvas/2d/lib/components/CodeBlock';
 
 const codeRef = createRef();
 yield view.add(
@@ -165,7 +165,8 @@ for future edits. Then call `edit` with an embedded `insert` call to add the new
 code.
 
 ```tsx
-import {CodeBlock, insert} from '@motion-canvas/2d/lib/components';
+import {insert} from '@motion-canvas/2d/lib/components';
+import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock'
 import {createRef} from '@motion-canvas/core/lib/utils';
 
 const codeRef = createRef<CodeBlock>();
@@ -186,7 +187,8 @@ Removing code is similar, only with the provided code being removed during the
 animation.
 
 ```tsx
-import {CodeBlock, remove} from '@motion-canvas/2d/lib/components';
+import {remove} from '@motion-canvas/2d/lib/components';
+import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock'
 
 yield view.add(<CodeBlock ref={codeRef} code={`var myBool = true;`} />);
 


### PR DESCRIPTION
Due to #401 the codeblock component is no longer exported from the components index. Docs should be updated to reflect this change