### PR TITLE
Changed Nullish Coalescing assignment operator to first test then assign

### DIFF
--- a/packages/vite-plugin/src/proxy-middleware.ts
+++ b/packages/vite-plugin/src/proxy-middleware.ts
@@ -72,8 +72,8 @@ export function motionCanvasCorsProxy(
   config: MotionCanvasCorsProxyOptions,
 ) {
   // Set the default config if no config was provided
-  config.allowedMimeTypes ??= ['image/*', 'video/*'];
-  config.allowListHosts ??= [];
+  config.allowedMimeTypes ?? (config.allowedMimeTypes = ['image/*', 'video/*']);
+  config.allowListHosts ?? (config.allowListHosts = []);
 
   // Check the Mime Types to have a correct structure (left/right)
   // not having them in the correct format would crash the Middleware


### PR DESCRIPTION
After running: 
`npm init @motion-canvas`
`npm install`
`npm run serve`
An error occurs saying 
```
failed to load config from P:\Video\Educational\CORDIC\CODE\cordic\vite.config.ts
error when starting dev server:
.\project-directory\node_modules\@motion-canvas\vite-plugin\lib\proxy-middleware.js:40
    config.allowedMimeTypes ??= ['image/*', 'video/*'];
                            ^^^
SyntaxError: Unexpected token '??='
```

Code causing the issue in [`motion-canvas/packages/vite-plugin/src/proxy-middleware.ts`](https://github.com/motion-canvas/motion-canvas/blob/main/packages/vite-plugin/src/proxy-middleware.ts)
```ts
export function motionCanvasCorsProxy(
  middleware: Connect.Server,
  config: MotionCanvasCorsProxyOptions,
) {
  // Set the default config if no config was provided
  config.allowedMimeTypes ??= ['image/*', 'video/*'];  // These two lines are where the problem occurs
  config.allowListHosts ??= [];                        // Line 2

  // Check the Mime Types to have a correct structure (left/right)
  // not having them in the correct format would crash the Middleware
  // further down below
  if ((config.allowedMimeTypes ?? []).some(e => e.split('/').length !== 2)) {
    throw new Error(
      "Invalid config for Proxy:\nAll Entries must have the following format:\n 'left/right' where left may be '*'",
    );
  }
```
Changed `a ??= b` to `a ?? (a = b)`, which now fixes the `npm run serve` error.