### PR TITLE
Add `XY` types of methods to Vector2

### DIFF
--- a/packages/core/src/types/Vector.ts
+++ b/packages/core/src/types/Vector.ts
@@ -229,23 +229,28 @@ export class Vector2 implements Type {
     );
   }
 
-  public mul(vector: Vector2) {
+  public mul(possibleVector: PossibleVector2) {
+    const vector = new Vector2(possibleVector);
     return new Vector2(this.x * vector.x, this.y * vector.y);
   }
 
-  public div(vector: Vector2) {
+  public div(possibleVector: PossibleVector2) {
+    const vector = new Vector2(possibleVector);
     return new Vector2(this.x / vector.x, this.y / vector.y);
   }
 
-  public add(vector: Vector2) {
+  public add(possibleVector: PossibleVector2) {
+    const vector = new Vector2(possibleVector);
     return new Vector2(this.x + vector.x, this.y + vector.y);
   }
 
-  public sub(vector: Vector2) {
+  public sub(possibleVector: PossibleVector2) {
+    const vector = new Vector2(possibleVector);
     return new Vector2(this.x - vector.x, this.y - vector.y);
   }
 
-  public dot(vector: Vector2): number {
+  public dot(possibleVector: PossibleVector2): number {
+    const vector = new Vector2(possibleVector);
     return this.x * vector.x + this.y * vector.y;
   }
 


### PR DESCRIPTION
I propose to add methods with suffix `XY` that accepts 2 numbers: x and y`.

WDYT?

PS
Of course this PR is just POC. It requires to add more methods with this suffix