### PR TITLE
fix(docs): initialState fixes for Switch Custom Components example

### DIFF
--- a/packages/examples/src/components/Switch.tsx
+++ b/packages/examples/src/components/Switch.tsx
@@ -39,13 +39,13 @@ export class Switch extends Node {
       ...props,
     });
 
-    this.indicatorPosition(this.initialState ? 50 : -50);
     this.isOn = this.initialState();
+    this.indicatorPosition(this.isOn ? 50 : -50);
 
     this.add(
       <Rect
         ref={this.container}
-        fill={this.offColor}
+        fill={this.isOn ? this.accent() : this.offColor}
         size={[200, 100]}
         radius={100}
       >


### PR DESCRIPTION
- when `Switch` was `initialState=true`, it would have the `offColor` for frame 0
- when `Switch` was `initialState=false`, the position of the circle would be in the on position since it used `this.initialState` instead of `this.initialState()` or `this.isOn`