### PR TITLE
fix(docs): transitions example has invalid source code link (#499)

### DIFF
--- a/packages/docs/docs/getting-started/transitions.mdx
+++ b/packages/docs/docs/getting-started/transitions.mdx
@@ -59,7 +59,7 @@ export default makeScene2D(function* (view) {
 });
 ```
 
-<AnimationPlayer small name={'transitions'} />
+<AnimationPlayer small name={'transitions'} link={'transitions-second'} />
 
 :::caution
 

--- a/packages/docs/src/components/AnimationPlayer/index.tsx
+++ b/packages/docs/src/components/AnimationPlayer/index.tsx
@@ -22,12 +22,14 @@ export interface AnimationPlayerProps {
   banner?: boolean;
   small?: boolean;
   name: string;
+  link?: string;
 }
 
 export default function AnimationPlayer({
   name,
   banner,
   small,
+  link,
 }: AnimationPlayerProps) {
   return (
     <div
@@ -42,7 +44,7 @@ export default function AnimationPlayer({
         src={`/examples/${name}.js`}
         auto={banner}
       />
-      <AnimationLink name={name} />
+      <AnimationLink name={link || name} />
     </div>
   );
 }


### PR DESCRIPTION
An optional Link prop has been introduced to AnimationPlayer, to specify a separate source link in cases where the name of the example and scene file are not the same.

An alternative solution would be to ensure consistency by updating the file name "transitions-second" to simply "transitions".