### PR TITLE
fix(Rect): correct a typo in Rect.ts

### DIFF
--- a/packages/2d/src/components/Rect.ts
+++ b/packages/2d/src/components/Rect.ts
@@ -51,7 +51,7 @@ export class Rect extends Shape {
   public declare readonly smoothCorners: SimpleSignal<boolean, this>;
 
   /**
-   * Controlls the sharpness of the corners. {@link Rect.smoothCorners} must
+   * Controls the sharpness of the corners. {@link Rect.smoothCorners} must
    * be set to `true`.
    *
    * @remarks


### PR DESCRIPTION
Fix a typo in Rect.ts by changing "controll" to "control."