### PR TITLE
feat(core): tree shaking

### DIFF
--- a/packages/2d/package.json
+++ b/packages/2d/package.json
@@ -13,6 +13,7 @@
     "build": "ttsc",
     "watch": "ttsc -w"
   },
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/motion-canvas/motion-canvas.git"

--- a/packages/2d/src/components/Txt.ts
+++ b/packages/2d/src/components/Txt.ts
@@ -5,6 +5,7 @@ import {Shape, ShapeProps} from './Shape';
 import {BBox} from '@motion-canvas/core/lib/types';
 import {SignalValue, SimpleSignal} from '@motion-canvas/core/lib/signals';
 import {View2D} from './View2D';
+import {lazy} from '@motion-canvas/core/lib/decorators';
 
 export interface TxtProps extends ShapeProps {
   children?: string;
@@ -12,21 +13,23 @@ export interface TxtProps extends ShapeProps {
 }
 
 export class Txt extends Shape {
-  protected static segmenter;
-  protected static formatter: HTMLDivElement;
+  @lazy(() => {
+    const formatter = document.createElement('div');
+    View2D.shadowRoot.append(formatter);
+    return formatter;
+  })
+  protected static readonly segmenter: any;
 
-  static {
-    this.formatter = document.createElement('div');
-    View2D.shadowRoot.append(this.formatter);
-
+  @lazy(() => {
     try {
-      this.segmenter = new (Intl as any).Segmenter(undefined, {
+      return new (Intl as any).Segmenter(undefined, {
         granularity: 'grapheme',
       });
     } catch (e) {
-      // do nothing
+      return null;
     }
-  }
+  })
+  protected static formatter: HTMLDivElement;
 
   @initial('')
   @interpolation(textLerp)

--- a/packages/2d/src/components/View2D.ts
+++ b/packages/2d/src/components/View2D.ts
@@ -2,20 +2,15 @@ import {Rect, RectProps} from './Rect';
 import {initial, signal} from '../decorators';
 import {PlaybackState} from '@motion-canvas/core';
 import {SimpleSignal} from '@motion-canvas/core/lib/signals';
+import {lazy} from '@motion-canvas/core/lib/decorators';
 
 export class View2D extends Rect {
-  public static frameID = 'motion-canvas-2d-frame';
-  public static shadowRoot: ShadowRoot;
-
-  @initial(PlaybackState.Paused)
-  @signal()
-  public declare readonly playbackState: SimpleSignal<PlaybackState, this>;
-
-  static {
-    let frame = document.querySelector<HTMLDivElement>(`#${View2D.frameID}`);
+  @lazy(() => {
+    const frameID = 'motion-canvas-2d-frame';
+    let frame = document.querySelector<HTMLDivElement>(`#${frameID}`);
     if (!frame) {
       frame = document.createElement('div');
-      frame.id = View2D.frameID;
+      frame.id = frameID;
       frame.style.position = 'absolute';
       frame.style.pointerEvents = 'none';
       frame.style.top = '0';
@@ -24,8 +19,13 @@ export class View2D extends Rect {
       frame.style.overflow = 'hidden';
       document.body.prepend(frame);
     }
-    View2D.shadowRoot = frame.shadowRoot ?? frame.attachShadow({mode: 'open'});
-  }
+    return frame.shadowRoot ?? frame.attachShadow({mode: 'open'});
+  })
+  public static shadowRoot: ShadowRoot;
+
+  @initial(PlaybackState.Paused)
+  @signal()
+  public declare readonly playbackState: SimpleSignal<PlaybackState, this>;
 
   public constructor(props: RectProps) {
     super({

--- a/packages/2d/src/components/index.ts
+++ b/packages/2d/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Circle';
+export * from './CodeBlock';
 export * from './Icon';
 export * from './Img';
 export * from './Grid';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "watch": "ttsc -p tsconfig.build.json -w",
     "test": "vitest"
   },
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/motion-canvas/motion-canvas.git"

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -5,4 +5,5 @@
  */
 
 export * from './decorate';
+export * from './lazy';
 export * from './threadable';

--- a/packages/core/src/decorators/lazy.ts
+++ b/packages/core/src/decorators/lazy.ts
@@ -1,0 +1,29 @@
+const UNINITIALIZED = Symbol.for(
+  '@motion-canvas/core/decorators/UNINITIALIZED',
+);
+
+/**
+ * Create a lazy decorator.
+ *
+ * @remarks
+ * A property marked as lazy will not be initialized until it's requested for
+ * the first time. Lazy properties are read-only.
+ *
+ * Must be used for any static properties that require the DOM API to be
+ * initialized.
+ *
+ * @param factory - A function that returns the value of this property.
+ */
+export function lazy(factory: () => unknown): PropertyDecorator {
+  return (target, propertyKey) => {
+    let value: unknown = UNINITIALIZED;
+    Object.defineProperty(target, propertyKey, {
+      get(): any {
+        if (value === UNINITIALIZED) {
+          value = factory.call(this);
+        }
+        return value;
+      },
+    });
+  };
+}

--- a/packages/core/src/media/AudioManager.ts
+++ b/packages/core/src/media/AudioManager.ts
@@ -9,7 +9,7 @@ export class AudioManager {
   }
   private readonly data = new ValueDispatcher<AudioData | null>(null);
 
-  private static readonly context = new AudioContext();
+  private readonly context = new AudioContext();
   private readonly audioElement: HTMLAudioElement = new Audio();
   private source: string | null = null;
   private error = false;
@@ -164,7 +164,7 @@ export class AudioManager {
 
   private decodeAudioData(buffer: ArrayBuffer): Promise<AudioBuffer> {
     return new Promise<AudioBuffer>((resolve, reject) =>
-      AudioManager.context.decodeAudioData(buffer, resolve, reject),
+      this.context.decodeAudioData(buffer, resolve, reject),
     );
   }
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,7 +4,6 @@ import markdownLiterals from '@motion-canvas/internal/vite/markdown-literals';
 export default defineConfig({
   plugins: [markdownLiterals()],
   test: {
-    setupFiles: ['./vitest.setup.ts'],
     environment: 'jsdom',
   },
 });

--- a/packages/core/vitest.setup.ts
+++ b/packages/core/vitest.setup.ts
@@ -1,3 +1,0 @@
-import {vi} from 'vitest';
-
-vi.stubGlobal('AudioContext', class {});


### PR DESCRIPTION
This PR makes tree shaking work correctly.
The `CodeBlock` and `Latex` nodes are now correctly excluded when not used in the project.

**Previously**
![image](https://user-images.githubusercontent.com/64662184/225101401-ffc83bbb-4011-4262-9e23-245203ad48a7.png)

**Now**
![image](https://user-images.githubusercontent.com/64662184/225100930-1a1e74f6-58d7-4184-86e7-ec78ecf0e7ec.png)
