### PR TITLE
fix(2d): clip Txt by default

### DIFF
--- a/packages/2d/src/components/Txt.ts
+++ b/packages/2d/src/components/Txt.ts
@@ -92,6 +92,9 @@ export class Txt extends Shape {
     const y = box.y + box.height / 2;
     context.save();
     context.textBaseline = 'middle';
+    const clipPath = new Path2D();
+    clipPath.rect(box.x, box.y, box.width, this.getHeight());
+    context.clip(clipPath);
 
     if (this.lineWidth() <= 0) {
       context.fillText(text, box.x, y);


### PR DESCRIPTION
Clip Txt by default to prevent confusing behavior where text clips only while animating. I only enacted this change for text height as I didn't know whether it would potentially affect text wrapping in the future.

Fixes #465