### PR TITLE
docs: add spline documentation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid",
         "filter": {
-          "regex": "^(__html|_jsx|_jsxs|_Fragment)$",
+          "regex": "^(__html)$",
           "match": false
         }
       },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid",
         "filter": {
-          "regex": "^(__html|_jsx)$",
+          "regex": "^(__html|_jsx|_jsxs|_Fragment)$",
           "match": false
         }
       },

--- a/packages/docs/docs/components/custom-components.mdx
+++ b/packages/docs/docs/components/custom-components.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 slug: /custom-components
 ---
 

--- a/packages/docs/docs/components/spline.mdx
+++ b/packages/docs/docs/components/spline.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 slug: /spline
 ---
 
@@ -34,8 +34,8 @@ export default makeScene2D(function* (view) {
 });
 ```
 
-The `Spline` component allows us to draw and animate smooth curves through a
-series of control points.
+The [`Spline`][spline] component allows us to draw and animate smooth curves
+through a series of control points.
 
 ## Defining control points
 
@@ -220,9 +220,8 @@ property.
 ```
 
 `auto` should be a value between `0` and `1` and represents the percentage of
-how much to blend between the user-provided handles and auto-calculated handles.
-A value of `1` means to use the auto handles while a value of `0` means using
-the user handles.
+how much to blend between the user-provided handles (`0`) and auto-calculated
+handles (`1`).
 
 :::tip
 
@@ -248,7 +247,7 @@ export default makeScene2D(function* (view) {
   const knots: Knot[] = [];
 
   view.add(
-    <Spline lineWidth={16} stroke={'lightseagreen'} closed>
+    <Spline lineWidth={16} stroke={'lightseagreen'} lineJoin={'round'} closed>
       <Knot
         ref={makeRef(knots, 0)}
         position={[-50, -80]}
@@ -335,18 +334,26 @@ export default makeScene2D(function* (view) {
 
 ### Animating the knots of a spline
 
-Since the `Knot` node is a regular Motion Canvas component, it can be animated
-in much the same way as other components.
+`Knot`s can be animated in much the same way as other components.
 
 :::note
 
 Animating a spline's knots is only possible when using the
-[Knot](#using-knot-nodes) component, not when using the `points` property.
+[`Knot`](#using-knot-nodes) component, not when using the `points` property.
 
 :::
 
 Below are a few examples of interesting effects that can be achieved by
 animating different properties of knots.
+
+:::tip
+
+You can think of `startHandle` and `endHandle` as being the children of the
+Knot—changing the knot's position, rotation and scale will also transform the
+handles. The only exceptions are `auto` handles which are unaffected by these
+transformations.
+
+:::
 
 <Tabs>
   <TabItem value='position' label='Position' default>
@@ -382,16 +389,6 @@ export default makeScene2D(function* (view) {
 
   <TabItem value="rotation" label="Rotation">
 
-Since `startHandle` and `endHandle` are relative to the knot, rotating the knot
-will also change the handle positions.
-
-:::caution
-
-Note that animating a knot's `rotation` is only possible if its `auto` value is
-less than `1`.
-
-:::
-
 ```tsx editor
 export default makeScene2D(function* (view) {
   const knot = createRef<Knot>();
@@ -411,16 +408,6 @@ export default makeScene2D(function* (view) {
   </TabItem>
 
   <TabItem value="scale" label="Scale">
-
-Since `startHandle` and `endHandle` are relative to the knot, scaling the knot
-will also change the handle positions.
-
-:::caution
-
-Note that animating a knot's `scale` is only possible if its `auto` value is
-less than `1`.
-
-:::
 
 ```tsx editor
 export default makeScene2D(function* (view) {
@@ -444,9 +431,8 @@ export default makeScene2D(function* (view) {
 
 ### Animating objects along a spline
 
-Splines are often used to animate objects along a path. The same is possible in
-Motion Canvas by using the `getPointAtPercentage` method of the `Spline`
-component.
+Splines can be useful to model the path that an object should follow. You can
+use the `getPointAtPercentage` method to achieve this.
 
 ```tsx editor
 export default makeScene2D(function* (view) {
@@ -486,6 +472,7 @@ The `getPointAtPercentage` method returns a [`CurvePoint`][curve-point] object
 which contains the position of the point that sits at the given percentage along
 the spline's arclength as well as the point's tangent vector.
 
+[spline]: /api/2d/components/Spline
 [knot]: /api/2d/components/Knot
 [line]: /api/2d/components/Line
 [cardinal-spline]:

--- a/packages/docs/docs/components/spline.mdx
+++ b/packages/docs/docs/components/spline.mdx
@@ -237,9 +237,8 @@ the user handles.
 
 :::tip
 
-`auto` is a compound signal which means you can also specify `startHandleAuto`
-and `endHandleAuto` respectively to control the blend of each handle
-individually.
+`auto` is a compound signal, which means you can specify `startHandleAuto` and
+`endHandleAuto` to individually control the blend of each handle.
 
 ```tsx {5-6}
 <Knot

--- a/packages/docs/docs/components/spline.mdx
+++ b/packages/docs/docs/components/spline.mdx
@@ -5,7 +5,6 @@ slug: /spline
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import SplineSvg from '@site/static/img/media/spline.svg';
 
 # Spline
 
@@ -37,16 +36,6 @@ export default makeScene2D(function* (view) {
 
 The `Spline` component allows us to draw and animate smooth curves through a
 series of control points.
-
-## A gentle introduction to splines
-
-This section aims to be a simple introduction to the concept of splines in
-computer graphics. Feel free to [skip this section](#defining-control-points) if
-you're already familiar with splines.
-
-<div style={{display: 'flex', justifyContent: 'center'}}>
-  <SplineSvg style={{maxWidth: '430px'}} />
-</div>
 
 ## Defining control points
 
@@ -477,10 +466,14 @@ export default makeScene2D(function* (view) {
           [300, 0],
         ]}
       />
-      <Circle
+      <Rect
         size={26}
         fill={'lightseagreen'}
         position={() => spline().getPointAtPercentage(progress()).position}
+        rotation={() =>
+          (spline().getPointAtPercentage(progress()).tangent.radians * 180) /
+          Math.PI
+        }
       />,
     </>,
   );

--- a/packages/docs/docs/components/spline.mdx
+++ b/packages/docs/docs/components/spline.mdx
@@ -1,0 +1,501 @@
+---
+sidebar_position: 4
+slug: /spline
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import SplineSvg from '@site/static/img/media/spline.svg';
+
+# Spline
+
+```tsx editor
+import {makeScene2D} from '@motion-canvas/2d/lib/scenes';
+import {Spline, Knot} from '@motion-canvas/2d/lib/components';
+import {createRef} from '@motion-canvas/core/lib/utils';
+import {waitFor} from '@motion-canvas/core/lib/flow';
+
+export default makeScene2D(function* (view) {
+  const spline = createRef<Spline>();
+
+  view.add(
+    <Spline ref={spline} lineWidth={4} fill={'#e13238'} closed>
+      <Knot position={[-120, -30]} startHandle={[0, 70]} />
+      <Knot
+        position={[0, -50]}
+        startHandle={[-40, -60]}
+        endHandle={[40, -60]}
+      />
+      <Knot position={[120, -30]} startHandle={[0, -70]} />
+      <Knot position={[0, 100]} startHandle={[5, 0]} />
+    </Spline>,
+  );
+
+  yield* spline().scale(0.9, 0.6).to(1, 0.4);
+});
+```
+
+The `Spline` component allows us to draw and animate smooth curves through a
+series of control points.
+
+## A gentle introduction to splines
+
+This section aims to be a simple introduction to the concept of splines in
+computer graphics. Feel free to [skip this section](#defining-control-points) if
+you're already familiar with splines.
+
+<div style={{display: 'flex', justifyContent: 'center'}}>
+  <SplineSvg style={{maxWidth: '430px'}} />
+</div>
+
+## Defining control points
+
+In order to draw a spline, we need to specify what its knots are. The `Spline`
+component provides multiple ways of specifying these control points which we
+will go through in this section.
+
+### Using the `points` property
+
+The easiest way to define a spline's knots is by passing an array of positions
+via the spline's `points` property. Each point will be treated as the position
+of one of the spline's knots.
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  view.add(
+    <Spline
+      lineWidth={6}
+      stroke={'lightseagreen'}
+      points={[
+        [-300, 0],
+        [-150, -100],
+        [150, 100],
+        [300, 0],
+      ]}
+    />,
+  );
+});
+```
+
+The result is a curve that smoothly passes through each of the provided points.
+
+:::info
+
+Remember to provide a `lineWidth` and `stroke` to the spline as it won't be
+visible otherwise. Alternatively, you may also specify a `fill` color.
+
+:::
+
+We can alter the shape of the curve by passing a value between `0` and `1` to
+the `smoothness` property.
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  const spline = createRef<Spline>();
+
+  view.add(
+    <Spline
+      ref={spline}
+      lineWidth={6}
+      stroke={'lightseagreen'}
+      smoothness={0.4}
+      points={[
+        [-300, 0],
+        [-150, -100],
+        [150, 100],
+        [300, 0],
+      ]}
+    />,
+  );
+
+  yield* spline().smoothness(0, 1).to(1, 1).to(0.4, 1);
+});
+```
+
+While defining the knots in this way is very simple and can be enough for simple
+curves, there is an important limitation to this method: we cannot alter the
+position of the knot's handles. Instead, the handles get calculated
+automatically so that the curve passes smoothly through each point without any
+sharp or sudden turns.
+
+:::info Fun fact
+
+The auto handles are calculated based on the positions of a knot's two
+neighboring knots. A spline that calculates the handle positions of its knots in
+this way is called a [Cardinal Spline][cardinal-spline].
+
+:::
+
+Let's look at the second way of defining knots to learn how we can more finely
+control the shape of our spline.
+
+### Using `Knot` nodes
+
+The second way of defining knots is by—fittingly—using the [Knot][knot] node.
+The same spline from above can also be written like this.
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  view.add(
+    <Spline lineWidth={6} stroke={'lightseagreen'}>
+      <Knot position={[-300, 0]} />
+      <Knot position={[-150, -100]} />
+      <Knot position={[150, 100]} />
+      <Knot position={[300, 0]} />
+    </Spline>,
+  );
+});
+```
+
+As you can see, we get the exact same shape we did when using the `points`
+property. The advantage of defining the knots with `Knot` nodes is that it also
+allows us to control the positions of each knot's handles via the `startHandle`
+and `endHandle` properties.
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  view.add(
+    <Spline lineWidth={6} stroke={'lightseagreen'}>
+      <Knot position={[-300, 0]} />
+      <Knot position={[-150, -100]} endHandle={[-100, 0]} />
+      <Knot position={[150, 100]} startHandle={[100, 0]} />
+      <Knot position={[300, 0]} />
+    </Spline>,
+  );
+});
+```
+
+Note that handle positions are relative to the knot's position.
+
+:::note
+
+Similar to using the `points` property, if no explicit handles are provided for
+a knot, the handles get calculated automatically so that the curve smoothly
+passes through the knot.
+
+:::
+
+#### Mirrored handles
+
+Handles are mirrored by default. This means that when we provide only one of the
+handles of a knot, the other one will implicitly be set to a flipped version of
+the provided handle.
+
+```tsx
+<Knot startHandle={[100, 50]} />
+// Is the same as
+<Knot startHandle={[100, 50]} endHandle={[-100, -50]} />
+```
+
+#### Broken knots
+
+Providing both `startHandle` and `endHandle` results in a so-called **broken
+knot**. Broken knots are very useful because they allow us to add sharp corners
+to our spline.
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  view.add(
+    <Spline lineWidth={16} stroke={'lightseagreen'} closed>
+      <Knot position={[-50, -80]} startHandle={[0, 20]} endHandle={[90, 0]} />
+      <Knot position={[50, 0]} />
+      <Knot position={[-50, 80]} startHandle={[90, 0]} endHandle={[0, -20]} />
+    </Spline>,
+  );
+});
+```
+
+#### Blending between user handles and calculated handles
+
+By default, the auto-calculated handles get ignored when at least one of the
+`startHandle` or `endHandle` properties is provided. However, it is possible to
+blend between user-provided and auto-calculated handles by using the `auto`
+property.
+
+```tsx {6,13}
+<Spline lineWidth={16} stroke={'lightseagreen'} closed>
+  <Knot
+    position={[-50, -80]}
+    startHandle={[0, 20]}
+    endHandle={[90, 0]}
+    auto={0.5}
+  />
+  <Knot position={[50, 0]} />
+  <Knot
+    position={[-50, 80]}
+    startHandle={[90, 0]}
+    endHandle={[0, -20]}
+    auto={0.5}
+  />
+</Spline>
+```
+
+`auto` should be a value between `0` and `1` and represents the percentage of
+how much to blend between the user-provided handles and auto-calculated handles.
+A value of `1` means to use the auto handles while a value of `0` means using
+the user handles.
+
+:::tip
+
+`auto` is a compound signal which means you can also specify `startHandleAuto`
+and `endHandleAuto` respectively to control the blend of each handle
+individually.
+
+```tsx {5-6}
+<Knot
+  position={[0, 0]}
+  startHandle={[-50, -50]}
+  endHandle={[30, 0]}
+  startHandleAuto={0.3}
+  endHandleAuto={0.8}
+/>
+```
+
+:::
+
+Since `auto` is a signal, it can also be animated.
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  const knots: Knot[] = [];
+
+  view.add(
+    <Spline lineWidth={16} stroke={'lightseagreen'} closed>
+      <Knot
+        ref={makeRef(knots, 0)}
+        position={[-50, -80]}
+        startHandle={[0, 20]}
+        endHandle={[90, 0]}
+      />
+      <Knot position={[50, 0]} />
+      <Knot
+        ref={makeRef(knots, 1)}
+        position={[-50, 80]}
+        startHandle={[90, 0]}
+        endHandle={[0, -20]}
+      />
+    </Spline>,
+  );
+
+  yield* all(...knots.map(knot => knot.auto(1, 1).to(0, 1)));
+});
+```
+
+## Animating splines
+
+While animating splines isn't too different from animating any other node, this
+section aims to illustrate a few of the most common use cases.
+
+### Drawing splines
+
+Similar to the [`Line`][line] component, the `Spline` node provides `start` and
+`end` signals which allow us to control the segment of the curve that should be
+visible. Both `start` and `end` are values between `0` and `1` and represent the
+percentage of the spline's arclength from which to start drawing from.
+
+```tsx {7-8}
+<Spline
+  points={[
+    [-300, 0],
+    [-150, -100],
+    [150, 100],
+  ]}
+  start={0.4}
+  end={0.8}
+/>
+```
+
+The example above would draw the spline starting at 40% of the spline's
+arclength (`start={0.4}`) and draw it up until 80% of the spline's arclength
+(`end={0.8}`).
+
+:::note
+
+When using `start` and `end` in conjunction with `startOffset` and `endOffset`,
+`start` and `end` will be relative to the _remaining_ length of the spline after
+taking the offset into account.
+
+:::
+
+We can then animate drawing a spline by tweening these properties:
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  const spline = createRef<Spline>();
+
+  view.add(
+    <Spline
+      ref={spline}
+      lineWidth={6}
+      stroke={'lightseagreen'}
+      points={[
+        [-300, 0],
+        [-150, -100],
+        [150, 100],
+        [300, 0],
+      ]}
+      end={0}
+    />,
+  );
+
+  yield* spline().end(1, 1.5);
+  yield* spline().start(1, 1.5).to(0.5, 1);
+  yield* spline().end(0.5, 1);
+  yield* all(spline().start(0, 1.5), spline().end(1, 1.5));
+});
+```
+
+### Animating the knots of a spline
+
+Since the `Knot` node is a regular Motion Canvas component, it can be animated
+in much the same way as other components.
+
+:::note
+
+Animating a spline's knots is only possible when using the
+[Knot](#using-knot-nodes) component, not when using the `points` property.
+
+:::
+
+Below are a few examples of interesting effects that can be achieved by
+animating different properties of knots.
+
+<Tabs>
+  <TabItem value='position' label='Position' default>
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  const knotPositions: PossibleVector2[] = [
+    [-200, 0],
+    [-100, -80],
+    [0, 80],
+    [100, -80],
+    [200, 0],
+  ];
+  const knots: Knot[] = [];
+
+  view.add(
+    <Spline lineWidth={6} stroke={'lightseagreen'}>
+      {knotPositions.map((pos, i) => (
+        <Knot ref={makeRef(knots, i)} position={pos} />
+      ))}
+    </Spline>,
+  );
+
+  yield* all(
+    knots[1].position.y(80, 1).to(-80, 1),
+    knots[2].position.y(-80, 1).to(80, 1),
+    knots[3].position.y(80, 1).to(-80, 1),
+  );
+});
+```
+
+  </TabItem>
+
+  <TabItem value="rotation" label="Rotation">
+
+Since `startHandle` and `endHandle` are relative to the knot, rotating the knot
+will also change the handle positions.
+
+:::caution
+
+Note that animating a knot's `rotation` is only possible if its `auto` value is
+less than `1`.
+
+:::
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  const knot = createRef<Knot>();
+
+  view.add(
+    <Spline lineWidth={6} stroke={'lightseagreen'}>
+      <Knot position={[-100, 30]} />
+      <Knot ref={knot} position={[0, -50]} startHandle={[-70, 0]} />
+      <Knot position={[100, 30]} />
+    </Spline>,
+  );
+
+  yield* knot().rotation(360, 3, linear).to(0, 3);
+});
+```
+
+  </TabItem>
+
+  <TabItem value="scale" label="Scale">
+
+Since `startHandle` and `endHandle` are relative to the knot, scaling the knot
+will also change the handle positions.
+
+:::caution
+
+Note that animating a knot's `scale` is only possible if its `auto` value is
+less than `1`.
+
+:::
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  const knot = createRef<Knot>();
+
+  view.add(
+    <Spline lineWidth={6} stroke={'lightseagreen'}>
+      <Knot position={[-100, 30]} />
+      <Knot ref={knot} position={[0, -50]} startHandle={[-70, 0]} />
+      <Knot position={[100, 30]} />
+    </Spline>,
+  );
+
+  yield* knot().scale(3, 2).to(0.2, 2).to(1, 1);
+});
+```
+
+  </TabItem>
+
+</Tabs>
+
+### Animating objects along a spline
+
+Splines are often used to animate objects along a path. The same is possible in
+Motion Canvas by using the `getPointAtPercentage` method of the `Spline`
+component.
+
+```tsx editor
+export default makeScene2D(function* (view) {
+  const spline = createRef<Spline>();
+  const progress = createSignal(0);
+
+  view.add(
+    <>
+      <Spline
+        ref={spline}
+        lineWidth={6}
+        stroke={'lightgray'}
+        points={[
+          [-300, 0],
+          [-150, -100],
+          [150, 100],
+          [300, 0],
+        ]}
+      />
+      <Circle
+        size={26}
+        fill={'lightseagreen'}
+        position={() => spline().getPointAtPercentage(progress()).position}
+      />,
+    </>,
+  );
+
+  yield* progress(1, 2).to(0, 2);
+});
+```
+
+The `getPointAtPercentage` method returns a [`CurvePoint`][curve-point] object
+which contains the position of the point that sits at the given percentage along
+the spline's arclength as well as the point's tangent vector.
+
+[knot]: /api/2d/components/Knot
+[line]: /api/2d/components/Line
+[cardinal-spline]:
+  https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Cardinal_spline
+[curve-point]: /api/2d/curves/CurvePoint

--- a/packages/docs/src/components/Fiddle/runtime.ts
+++ b/packages/docs/src/components/Fiddle/runtime.ts
@@ -1,5 +1,5 @@
 import {makeScene2D} from '@motion-canvas/2d';
-import {jsx} from '@motion-canvas/2d/lib/jsx-runtime';
+import {jsx, Fragment} from '@motion-canvas/2d/lib/jsx-runtime';
 import * as components from '@motion-canvas/2d/lib/components';
 import * as flow from '@motion-canvas/core/lib/flow';
 import * as utils from '@motion-canvas/core/lib/utils';
@@ -16,6 +16,8 @@ export default {
   ...types,
   ...tweening,
   ...threading,
+  _Fragment: Fragment,
   _jsx: jsx,
+  _jsxs: jsx,
   makeScene2D,
 };

--- a/packages/docs/src/components/Fiddle/runtime.ts
+++ b/packages/docs/src/components/Fiddle/runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import {makeScene2D} from '@motion-canvas/2d';
 import {jsx, Fragment} from '@motion-canvas/2d/lib/jsx-runtime';
 import * as components from '@motion-canvas/2d/lib/components';

--- a/packages/docs/static/img/media/spline.svg
+++ b/packages/docs/static/img/media/spline.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 420 175">
+  <style>
+    @media (max-width: 420px) {
+      #curve {
+        stroke-width: 4;
+      }
+      #controls {
+        stroke-width: 2;
+      }
+      text {
+        font-size: 16px;
+        transform: translateY(1px);
+      }
+      rect {
+        width: 100px;
+      }
+    }
+  </style>
+
+  <path id="curve" stroke="#CCCCD3" stroke-width="3" d="M95.5 156c19-59.5 66-97.962 146.5-71 104.5 35 151 3.5 164.5-65.5"/>
+  <path id="controls" stroke="#CCCCD3" d="M95.5 156 114 97.5M162 58.5l183.5 61M393 88.5 406.5 20"/>
+  <circle cx="95" cy="156" r="5" fill="var(--ifm-color-primary)"/>
+  <circle cx="114" cy="97" r="3.5" fill="var(--ifm-background-color)" stroke="var(--ifm-color-primary)" stroke-width="1.5"/>
+  <circle cx="162" cy="59" r="3.5" fill="var(--ifm-background-color)" stroke="var(--ifm-color-primary)" stroke-width="1.5"/>
+  <circle cx="345" cy="119" r="3.5" fill="var(--ifm-background-color)" stroke="var(--ifm-color-primary)" stroke-width="1.5"/>
+  <circle cx="393" cy="89" r="3.5" fill="var(--ifm-background-color)" stroke="var(--ifm-color-primary)" stroke-width="1.5"/>
+  <circle cx="242" cy="85" r="5" fill="var(--ifm-color-primary)"/>
+  <circle cx="406" cy="19" r="5" fill="var(--ifm-color-primary)"/>
+
+  <rect width="93" height="63" x="5" y="7" fill="var(--hl-background)" rx="7"/>
+  <circle cx="23" cy="51" r="4.5" fill="var(--ifm-background-color)" stroke="var(--ifm-color-primary)" stroke-width="1.5"/>
+  <circle cx="23" cy="26" r="5" fill="var(--ifm-color-primary)"/>
+  <text xml:space="preserve" fill="var(--ifm-font-color-base)" font-family="var(--ifm-font-family-base)" font-size="13" font-weight="500" letter-spacing="0em" style="white-space:pre"><tspan x="35" y="30.5">Knot</tspan></text>
+  <text xml:space="preserve" fill="var(--ifm-font-color-base)" font-family="var(--ifm-font-family-base)" font-size="13" font-weight="500" letter-spacing="0em" style="white-space:pre"><tspan x="35" y="54.864">Handle</tspan></text>
+</svg>


### PR DESCRIPTION
This PR adds documentation for the new `Spline` node merged in #514. The section `A gentle introduction to splines` is still a work in progress, but the rest should be ready to be reviewed.