### PR TITLE
feat(core): extend Vector2 type

### DIFF
--- a/packages/core/src/types/Matrix.ts
+++ b/packages/core/src/types/Matrix.ts
@@ -1,7 +1,5 @@
 import {Vector2} from './Vector';
 
-export const EPSILON = 0.000001;
-
 export function transformAngle(angle: number, matrix: DOMMatrix) {
   const radians = (angle / 180) * Math.PI;
   const vector = Vector2.fromRadians(radians).transform(matrix);

--- a/packages/core/src/types/Matrix2D.ts
+++ b/packages/core/src/types/Matrix2D.ts
@@ -1,4 +1,4 @@
-import {EPSILON} from './Matrix';
+import {Type, EPSILON} from './Type';
 import {PossibleVector2, Vector2} from './Vector';
 
 export type PossibleMatrix2D =
@@ -28,7 +28,11 @@ export type PossibleMatrix2D =
  *   - (rA)^-1 = r^-1 A^-1, r != 0 does not hold for a Matrix2D
  *   - r(AB) = (rA)B = A(rB) does not hold for a Matrix2D
  */
-export class Matrix2D {
+export class Matrix2D implements Type {
+  public static readonly symbol = Symbol.for(
+    '@motion-canvas/core/types/Matrix2D',
+  );
+
   public readonly values: Float32Array = new Float32Array(6);
   public static readonly identity: Matrix2D = new Matrix2D(1, 0, 0, 1, 0, 0);
   public static readonly zero: Matrix2D = new Matrix2D(0, 0, 0, 0, 0, 0);
@@ -657,14 +661,23 @@ export class Matrix2D {
     );
   }
 
+  public toSymbol(): symbol {
+    return Matrix2D.symbol;
+  }
+
   public equals(other: Matrix2D, threshold: number = EPSILON): boolean {
     return (
-      Math.abs(this.values[0] - other.values[0]) <= threshold &&
-      Math.abs(this.values[1] - other.values[1]) <= threshold &&
-      Math.abs(this.values[2] - other.values[2]) <= threshold &&
-      Math.abs(this.values[3] - other.values[3]) <= threshold &&
-      Math.abs(this.values[4] - other.values[4]) <= threshold &&
-      Math.abs(this.values[5] - other.values[5]) <= threshold
+      Math.abs(this.values[0] - other.values[0]) <=
+        threshold + Number.EPSILON &&
+      Math.abs(this.values[1] - other.values[1]) <=
+        threshold + Number.EPSILON &&
+      Math.abs(this.values[2] - other.values[2]) <=
+        threshold + Number.EPSILON &&
+      Math.abs(this.values[3] - other.values[3]) <=
+        threshold + Number.EPSILON &&
+      Math.abs(this.values[4] - other.values[4]) <=
+        threshold + Number.EPSILON &&
+      Math.abs(this.values[5] - other.values[5]) <= threshold + Number.EPSILON
     );
   }
 

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -1,3 +1,5 @@
+export const EPSILON = 0.000001;
+
 export interface Type {
   toSymbol(): symbol;
 }

--- a/packages/core/src/types/Vector.test.ts
+++ b/packages/core/src/types/Vector.test.ts
@@ -40,4 +40,81 @@ describe('Vector2', () => {
     expect(vector()).toMatchObject({x: 3, y: 2});
     expect(vector.x()).toBe(3);
   });
+
+  test.each([
+    [[0, 0], 0],
+    [[1, 1], 45],
+    [[0, 1], 90],
+    [[-1, 1], 135],
+    [[-1, 0], 180],
+    [[-1, -1], 225],
+    [[0, -1], 270],
+    [[1, -1], 315],
+  ])(
+    'Computes angle of vector with positive x-axis in degrees: (%s, %s)',
+    (points, expected) => {
+      const vector = new Vector2(points[0], points[1]);
+
+      expect(vector.degrees).toBe(expected);
+      expect(Vector2.degrees(points[0], points[1])).toBe(expected);
+    },
+  );
+
+  describe('equality', () => {
+    test('equal if all components are exactly equal', () => {
+      const a = new Vector2(2.5, 2.5);
+      const b = new Vector2(2.5, 2.5);
+
+      expect(a.equals(b)).toBe(true);
+      expect(b.equals(a)).toBe(true);
+    });
+
+    test('equal if all components are within epsilon of each other', () => {
+      const a = new Vector2(2.5, 2.5);
+      const b = new Vector2(2.499, 2.499);
+
+      expect(a.equals(b, 0.001)).toBe(true);
+      expect(b.equals(a, 0.001)).toBe(true);
+    });
+
+    test('not equal if not all components are within epsilon of each other', () => {
+      const a = new Vector2(2.5, 2.5);
+      const b = new Vector2(2.498, 2.498);
+
+      expect(a.equals(b, 0.001)).toBe(false);
+      expect(b.equals(a, 0.001)).toBe(false);
+    });
+
+    test('exactly equal if all components are exactly equal', () => {
+      const a = new Vector2(2.5, 2.5);
+      const b = new Vector2(2.5, 2.5);
+
+      expect(a.exactlyEquals(b)).toBe(true);
+      expect(b.exactlyEquals(a)).toBe(true);
+    });
+
+    test('not exactly equal if not all components are exactly equal', () => {
+      const a = new Vector2(2.5, 2.5);
+      const b = new Vector2(2.49, 2.49);
+
+      expect(a.exactlyEquals(b)).toBe(false);
+      expect(b.exactlyEquals(a)).toBe(false);
+    });
+  });
+
+  test.each([
+    [[0, 0], 0],
+    [[1, 0], 1],
+    [[0, 1], 1],
+    [[2, 1], 5],
+    [[-1, 3], 10],
+  ])(
+    'Computes the squared magnitude of the vector: (%s, %s)',
+    (points, expected) => {
+      const vector = new Vector2(points[0], points[1]);
+
+      expect(vector.squaredMagnitude).toBe(expected);
+      expect(Vector2.squaredMagnitude(points[0], points[1])).toBe(expected);
+    },
+  );
 });

--- a/packages/core/src/types/Vector.test.ts
+++ b/packages/core/src/types/Vector.test.ts
@@ -47,9 +47,9 @@ describe('Vector2', () => {
     [[0, 1], 90],
     [[-1, 1], 135],
     [[-1, 0], 180],
-    [[-1, -1], 225],
-    [[0, -1], 270],
-    [[1, -1], 315],
+    [[-1, -1], -135],
+    [[0, -1], -90],
+    [[1, -1], -45],
   ])(
     'Computes angle of vector with positive x-axis in degrees: (%s, %s)',
     (points, expected) => {

--- a/packages/core/src/types/Vector.ts
+++ b/packages/core/src/types/Vector.ts
@@ -117,8 +117,37 @@ export class Vector2 implements Type {
     return new Vector2(Math.cos(radians), Math.sin(radians));
   }
 
+  /**
+   * Return the angle in radians between the vector described by x and y and the
+   * positive x-axis.
+   *
+   * @param x - The x component of the vector.
+   * @param y - The y component of the vector.
+   */
+  public static radians(x: number, y: number) {
+    return Math.atan2(y, x);
+  }
+
+  /**
+   * Return the angle in degrees between the vector described by x and y and the
+   * positive x-axis.
+   *
+   * @param x - The x component of the vector.
+   * @param y - The y component of the vector.
+   *
+   * @remarks
+   * The returned angle will be between 0 and 360 degrees.
+   */
+  public static degrees(x: number, y: number) {
+    return (360 + (Vector2.radians(x, y) * 180) / Math.PI) % 360;
+  }
+
   public static magnitude(x: number, y: number) {
     return Math.sqrt(x * x + y * y);
+  }
+
+  public static squaredMagnitude(x: number, y: number) {
+    return x * x + y * y;
   }
 
   public get width(): number {
@@ -141,6 +170,10 @@ export class Vector2 implements Type {
     return Vector2.magnitude(this.x, this.y);
   }
 
+  public get squaredMagnitude(): number {
+    return Vector2.squaredMagnitude(this.x, this.y);
+  }
+
   public get normalized(): Vector2 {
     return this.scale(1 / Vector2.magnitude(this.x, this.y));
   }
@@ -161,8 +194,21 @@ export class Vector2 implements Type {
     return new Vector2(this.y, -this.x);
   }
 
+  /**
+   * Return the angle in radians between the vector and the positive x-axis.
+   */
   public get radians() {
-    return Math.atan2(this.y, this.x);
+    return Vector2.radians(this.x, this.y);
+  }
+
+  /**
+   * Return the angle in degrees between the vector and the positive x-axis.
+   *
+   * @remarks
+   * The returned angle will be between 0 and 360 degrees.
+   */
+  public get degrees() {
+    return Vector2.degrees(this.x, this.y);
   }
 
   public get ctg(): number {
@@ -270,7 +316,34 @@ export class Vector2 implements Type {
     return {x: this.x, y: this.y};
   }
 
+  /**
+   * Check if two vectors are exactly equal to each other.
+   *
+   * @remarks
+   * If you need to compensate for floating point inaccuracies, use the
+   * {@link equals} method, instead.
+   *
+   * @param other - The vector to compare.
+   */
   public exactlyEquals(other: Vector2): boolean {
     return this.x === other.x && this.y === other.y;
+  }
+
+  /**
+   * Check if two vectors are equal to each other.
+   *
+   * @remarks
+   * This method allows passing an allowed error margin when comparing vectors
+   * to compensate for floating point inaccuracies. To check if two vectors are
+   * exactly equal, use the {@link exactlyEquals} method, instead.
+   *
+   * @param other - The vector to compare.
+   * @param epsilon - The allowed error threshold when comparing the vectors.
+   */
+  public equals(other: Vector2, epsilon = 0.000001): boolean {
+    return (
+      Math.abs(this.x - other.x) <= epsilon + Number.EPSILON &&
+      Math.abs(this.y - other.y) <= epsilon + Number.EPSILON
+    );
   }
 }

--- a/packages/core/src/types/Vector.ts
+++ b/packages/core/src/types/Vector.ts
@@ -1,7 +1,7 @@
 import {arcLerp, InterpolationFunction} from '../tweening';
 import {map} from '../tweening/interpolationFunctions';
 import {Direction, Origin} from './Origin';
-import {Type} from './Type';
+import {EPSILON, Type} from './Type';
 import {
   CompoundSignal,
   CompoundSignalContext,
@@ -136,10 +136,10 @@ export class Vector2 implements Type {
    * @param y - The y component of the vector.
    *
    * @remarks
-   * The returned angle will be between 0 and 360 degrees.
+   * The returned angle will be between -180 and 180 degrees.
    */
   public static degrees(x: number, y: number) {
-    return (360 + (Vector2.radians(x, y) * 180) / Math.PI) % 360;
+    return (Vector2.radians(x, y) * 180) / Math.PI;
   }
 
   public static magnitude(x: number, y: number) {
@@ -205,7 +205,7 @@ export class Vector2 implements Type {
    * Return the angle in degrees between the vector and the positive x-axis.
    *
    * @remarks
-   * The returned angle will be between 0 and 360 degrees.
+   * The returned angle will be between -180 and 180 degrees.
    */
   public get degrees() {
     return Vector2.degrees(this.x, this.y);
@@ -338,12 +338,12 @@ export class Vector2 implements Type {
    * exactly equal, use the {@link exactlyEquals} method, instead.
    *
    * @param other - The vector to compare.
-   * @param epsilon - The allowed error threshold when comparing the vectors.
+   * @param threshold - The allowed error threshold when comparing the vectors.
    */
-  public equals(other: Vector2, epsilon = 0.000001): boolean {
+  public equals(other: Vector2, threshold = EPSILON): boolean {
     return (
-      Math.abs(this.x - other.x) <= epsilon + Number.EPSILON &&
-      Math.abs(this.y - other.y) <= epsilon + Number.EPSILON
+      Math.abs(this.x - other.x) <= threshold + Number.EPSILON &&
+      Math.abs(this.y - other.y) <= threshold + Number.EPSILON
     );
   }
 }


### PR DESCRIPTION
This PR adds a few more convenience methods to the `Vector2` type.

- `equals` allows comparing vectors with an additional error threshold to account for floating point inaccuracies.
- `degrees` returns the angle between the vector and the positive x-axis in degrees. A `radians` getter already existed.
- `squaredMagnitude` returns the squared magnitude of the vector. This one is really just for completeness' sake but you gotta save those frames!

I also added the corresponding static methods for `radians`, `degrees`, and `squaredMagnitude` to work similarly to `magnitude`.