### PR TITLE
fix(docs): small typo in updating.mdx

### DIFF
--- a/packages/docs/docs/migration/updating.mdx
+++ b/packages/docs/docs/migration/updating.mdx
@@ -15,7 +15,7 @@ following:
 npm update --save @motion-canvas/2d @motion-canvas/core @motion-canvas/ui @motion-canvas/vite-plugin
 ```
 
-## Toubleshooting
+## Troubleshooting
 
 If you get any errors, try removing `package-lock.json` and the `node_modules`
 folder, then run `npm install` again.


### PR DESCRIPTION
Fixing a small typo, from 'Toubleshooting' to 'Troubleshooting' in section title