### PR TITLE
fix(2d): fix wrong orientation of arrow for splines

### DIFF
--- a/packages/2d/src/components/Curve.ts
+++ b/packages/2d/src/components/Curve.ts
@@ -204,10 +204,10 @@ export abstract class Curve extends Shape {
     context.save();
     context.beginPath();
     if (this.endArrow()) {
-      this.drawArrow(context, endPoint, endTangent, arrowSize);
+      this.drawArrow(context, endPoint, endTangent, arrowSize, false);
     }
     if (this.startArrow()) {
-      this.drawArrow(context, startPoint, startTangent, arrowSize);
+      this.drawArrow(context, startPoint, startTangent, arrowSize, true);
     }
     context.fillStyle = resolveCanvasStyle(this.stroke(), context);
     context.closePath();
@@ -215,12 +215,14 @@ export abstract class Curve extends Shape {
     context.restore();
   }
 
-  private drawArrow(
+  protected drawArrow(
     context: CanvasRenderingContext2D | Path2D,
     center: Vector2,
     tangent: Vector2,
     arrowSize: number,
+    start: boolean,
   ) {
+    tangent = this.getArrowTangent(tangent, start);
     const normal = tangent.perpendicular;
     const origin = center.add(normal.scale(-arrowSize / 2));
 
@@ -230,4 +232,9 @@ export abstract class Curve extends Shape {
     lineTo(context, origin);
     context.closePath();
   }
+
+  protected abstract getArrowTangent(
+    pointTangent: Vector2,
+    start: boolean,
+  ): Vector2;
 }

--- a/packages/2d/src/components/Line.ts
+++ b/packages/2d/src/components/Line.ts
@@ -90,6 +90,10 @@ export class Line extends Curve {
     return coefficient;
   }
 
+  protected override getArrowTangent(pointTangent: Vector2): Vector2 {
+    return pointTangent;
+  }
+
   public override drawOverlay(
     context: CanvasRenderingContext2D,
     matrix: DOMMatrix,

--- a/packages/2d/src/components/Spline.ts
+++ b/packages/2d/src/components/Spline.ts
@@ -308,6 +308,15 @@ export class Spline extends Curve {
     context.stroke();
   }
 
+  protected override getArrowTangent(
+    pointTangent: Vector2,
+    start: boolean,
+  ): Vector2 {
+    return start
+      ? pointTangent.perpendicular.flipped
+      : pointTangent.perpendicular;
+  }
+
   private isKnot(node: Node): node is Knot {
     return node instanceof Knot;
   }


### PR DESCRIPTION
This PR fixes drawing arrowheads for splines as they were previously oriented incorrectly.

| Before | After |
| -------|------|
| <img width="460" alt="CleanShot 2023-03-30 at 08 20 18@2x" src="https://user-images.githubusercontent.com/5139098/228747613-3f7552ae-df2e-4f7b-bf58-a6e57a9f0de6.png"> | <img width="420" alt="CleanShot 2023-03-30 at 08 20 29@2x" src="https://user-images.githubusercontent.com/5139098/228747685-c9e5e760-ec61-43ee-b8e0-e0254ec482ba.png"> |

I'm not super married to this particular implementation but since we would have the same problem with any non-linear curve I thought it made sense to make each child class of `Curve` implement the logic on how to determine the correct tangent for the arrow head.