### PR TITLE
fix(2d): calculate arrow orientations for curves correctly

### DIFF
--- a/packages/2d/src/components/Curve.ts
+++ b/packages/2d/src/components/Curve.ts
@@ -118,20 +118,20 @@ export abstract class Curve extends Shape {
       const clampedStart = clamp(0, 1, relativeStart);
       const clampedEnd = clamp(0, 1, relativeEnd);
 
-      const [
-        currentStartPoint,
-        currentStartTangent,
-        currentEndPoint,
-        currentEndTangent,
-      ] = segment.draw(path, clampedStart, clampedEnd, startPoint === null);
+      const [startCurvePoint, endCurvePoint] = segment.draw(
+        path,
+        clampedStart,
+        clampedEnd,
+        startPoint === null,
+      );
 
       if (startPoint === null) {
-        startPoint = currentStartPoint;
-        startTangent = currentStartTangent;
+        startPoint = startCurvePoint.position;
+        startTangent = startCurvePoint.normal.flipped.perpendicular;
       }
 
-      endPoint = currentEndPoint;
-      endTangent = currentEndTangent;
+      endPoint = endCurvePoint.position;
+      endTangent = endCurvePoint.normal.flipped.perpendicular;
       if (length > end) {
         break;
       }
@@ -143,9 +143,9 @@ export abstract class Curve extends Shape {
 
     return {
       startPoint: startPoint ?? Vector2.zero,
-      startTangent: startTangent ?? Vector2.up,
+      startTangent: startTangent ?? Vector2.right,
       endPoint: endPoint ?? Vector2.zero,
-      endTangent: endTangent ?? Vector2.up,
+      endTangent: endTangent ?? Vector2.right,
       arrowSize,
       path,
       startOffset: start,
@@ -204,7 +204,7 @@ export abstract class Curve extends Shape {
     context.save();
     context.beginPath();
     if (this.endArrow()) {
-      this.drawArrow(context, endPoint, endTangent, arrowSize);
+      this.drawArrow(context, endPoint, endTangent.flipped, arrowSize);
     }
     if (this.startArrow()) {
       this.drawArrow(context, startPoint, startTangent, arrowSize);
@@ -222,11 +222,11 @@ export abstract class Curve extends Shape {
     arrowSize: number,
   ) {
     const normal = tangent.perpendicular;
-    const origin = center.add(normal.scale(-arrowSize / 2));
+    const origin = center.add(tangent.scale(-arrowSize / 2));
 
     moveTo(context, origin);
-    lineTo(context, origin.add(normal.add(tangent).scale(arrowSize)));
-    lineTo(context, origin.add(normal.sub(tangent).scale(arrowSize)));
+    lineTo(context, origin.add(tangent.add(normal).scale(arrowSize)));
+    lineTo(context, origin.add(tangent.sub(normal).scale(arrowSize)));
     lineTo(context, origin);
     context.closePath();
   }

--- a/packages/2d/src/curves/CircleSegment.ts
+++ b/packages/2d/src/curves/CircleSegment.ts
@@ -43,19 +43,19 @@ export class CircleSegment extends Segment {
       );
     }
 
-    const startTangent = Vector2.fromRadians(startAngle);
-    const endTangent = Vector2.fromRadians(endAngle);
+    const startNormal = Vector2.fromRadians(startAngle);
+    const endNormal = Vector2.fromRadians(endAngle);
 
     return [
       {
-        position: this.center.add(startTangent.scale(this.radius)),
-        tangent: this.counter ? startTangent : startTangent.flipped,
-        normal: this.counter ? startTangent : startTangent.flipped,
+        position: this.center.add(startNormal.scale(this.radius)),
+        tangent: this.counter ? startNormal : startNormal.flipped,
+        normal: this.counter ? startNormal : startNormal.flipped,
       },
       {
-        position: this.center.add(endTangent.scale(this.radius)),
-        tangent: this.counter ? endTangent.flipped : endTangent,
-        normal: this.counter ? endTangent.flipped : endTangent,
+        position: this.center.add(endNormal.scale(this.radius)),
+        tangent: this.counter ? endNormal.flipped : endNormal,
+        normal: this.counter ? endNormal.flipped : endNormal,
       },
     ];
   }
@@ -64,12 +64,12 @@ export class CircleSegment extends Segment {
     const counterFactor = this.counter ? -1 : 1;
     const angle = this.from.radians + distance * this.angle * counterFactor;
 
-    const tangent = Vector2.fromRadians(angle);
+    const normal = Vector2.fromRadians(angle);
 
     return {
-      position: this.center.add(tangent.scale(this.radius)),
-      tangent: this.counter ? tangent : tangent.flipped,
-      normal: this.counter ? tangent : tangent.flipped,
+      position: this.center.add(normal.scale(this.radius)),
+      tangent: this.counter ? normal : normal.flipped,
+      normal: this.counter ? normal : normal.flipped,
     };
   }
 }

--- a/packages/2d/src/curves/CircleSegment.ts
+++ b/packages/2d/src/curves/CircleSegment.ts
@@ -27,7 +27,7 @@ export class CircleSegment extends Segment {
     context: CanvasRenderingContext2D | Path2D,
     from: number,
     to: number,
-  ): [Vector2, Vector2, Vector2, Vector2] {
+  ): [CurvePoint, CurvePoint] {
     const counterFactor = this.counter ? -1 : 1;
     const startAngle = this.from.radians + from * this.angle * counterFactor;
     const endAngle = this.to.radians - (1 - to) * this.angle * counterFactor;
@@ -47,10 +47,16 @@ export class CircleSegment extends Segment {
     const endTangent = Vector2.fromRadians(endAngle);
 
     return [
-      this.center.add(startTangent.scale(this.radius)),
-      this.counter ? startTangent : startTangent.flipped,
-      this.center.add(endTangent.scale(this.radius)),
-      this.counter ? endTangent.flipped : endTangent,
+      {
+        position: this.center.add(startTangent.scale(this.radius)),
+        tangent: this.counter ? startTangent : startTangent.flipped,
+        normal: this.counter ? startTangent : startTangent.flipped,
+      },
+      {
+        position: this.center.add(endTangent.scale(this.radius)),
+        tangent: this.counter ? endTangent.flipped : endTangent,
+        normal: this.counter ? endTangent.flipped : endTangent,
+      },
     ];
   }
 
@@ -63,6 +69,7 @@ export class CircleSegment extends Segment {
     return {
       position: this.center.add(tangent.scale(this.radius)),
       tangent: this.counter ? tangent : tangent.flipped,
+      normal: this.counter ? tangent : tangent.flipped,
     };
   }
 }

--- a/packages/2d/src/curves/CurvePoint.ts
+++ b/packages/2d/src/curves/CurvePoint.ts
@@ -3,9 +3,10 @@ import type {Vector2} from '@motion-canvas/core/lib/types';
 export interface CurvePoint {
   position: Vector2;
   /**
-   * @deprecated The tangent is currently inconsistent for different types of
-   * curves and may sometimes return the normal of the point, instead. This will
-   * be fixed in the next major version but is kept as is for now for backwards
+   * @deprecated
+   * The tangent is currently inconsistent for different types of curves and may
+   * sometimes return the normal of the point, instead. This will be fixed in
+   * the next major version but is kept as is for now for backwards
    * compatibility reasons. To always get the real tangent of the point, you can
    * use `normal.flipped.perpendicular`, instead.
    */

--- a/packages/2d/src/curves/CurvePoint.ts
+++ b/packages/2d/src/curves/CurvePoint.ts
@@ -2,5 +2,13 @@ import type {Vector2} from '@motion-canvas/core/lib/types';
 
 export interface CurvePoint {
   position: Vector2;
+  /**
+   * @deprecated The tangent is currently inconsistent for different types of
+   * curves and may sometimes return the normal of the point, instead. This will
+   * be fixed in the next major version but is kept as is for now for backwards
+   * compatibility reasons. To always get the real tangent of the point, you can
+   * use `normal.flipped.perpendicular`, instead.
+   */
   tangent: Vector2;
+  normal: Vector2;
 }

--- a/packages/2d/src/curves/LineSegment.ts
+++ b/packages/2d/src/curves/LineSegment.ts
@@ -24,18 +24,34 @@ export class LineSegment extends Segment {
     start = 0,
     end = 1,
     move = false,
-  ): [Vector2, Vector2, Vector2, Vector2] {
+  ): [CurvePoint, CurvePoint] {
     const from = this.from.add(this.vector.scale(start));
     const to = this.from.add(this.vector.scale(end));
     if (move) {
       moveTo(context, from);
     }
     lineTo(context, to);
-    return [from, this.tangent.flipped, to, this.tangent];
+
+    return [
+      {
+        position: from,
+        tangent: this.tangent.flipped,
+        normal: this.tangent,
+      },
+      {
+        position: to,
+        tangent: this.tangent,
+        normal: this.tangent,
+      },
+    ];
   }
 
   public getPoint(distance: number): CurvePoint {
     const point = this.from.add(this.vector.scale(distance));
-    return {position: point, tangent: this.tangent.flipped};
+    return {
+      position: point,
+      tangent: this.tangent.flipped,
+      normal: this.tangent,
+    };
   }
 }

--- a/packages/2d/src/curves/LineSegment.ts
+++ b/packages/2d/src/curves/LineSegment.ts
@@ -6,13 +6,13 @@ import {CurvePoint} from './CurvePoint';
 export class LineSegment extends Segment {
   private readonly length: number;
   private readonly vector: Vector2;
-  private readonly tangent: Vector2;
+  private readonly normal: Vector2;
 
   public constructor(private from: Vector2, private to: Vector2) {
     super();
     this.vector = to.sub(from);
     this.length = this.vector.magnitude;
-    this.tangent = this.vector.perpendicular.normalized.safe;
+    this.normal = this.vector.perpendicular.normalized.safe;
   }
 
   public get arcLength(): number {
@@ -35,13 +35,13 @@ export class LineSegment extends Segment {
     return [
       {
         position: from,
-        tangent: this.tangent.flipped,
-        normal: this.tangent,
+        tangent: this.normal.flipped,
+        normal: this.normal,
       },
       {
         position: to,
-        tangent: this.tangent,
-        normal: this.tangent,
+        tangent: this.normal,
+        normal: this.normal,
       },
     ];
   }
@@ -50,8 +50,8 @@ export class LineSegment extends Segment {
     const point = this.from.add(this.vector.scale(distance));
     return {
       position: point,
-      tangent: this.tangent.flipped,
-      normal: this.tangent,
+      tangent: this.normal.flipped,
+      normal: this.normal,
     };
   }
 }

--- a/packages/2d/src/curves/PolynomialSegment.ts
+++ b/packages/2d/src/curves/PolynomialSegment.ts
@@ -32,9 +32,12 @@ export abstract class PolynomialSegment extends Segment {
    * @param t - The t value at which to evaluate the curve.
    */
   public eval(t: number): CurvePoint {
+    const tangent = this.tangent(t);
+
     return {
       position: this.curve.eval(t),
-      tangent: this.tangent(t),
+      tangent,
+      normal: tangent.perpendicular,
     };
   }
 
@@ -50,7 +53,11 @@ export abstract class PolynomialSegment extends Segment {
     const closestPoint = this.pointSampler.pointAtDistance(
       this.arcLength * distance,
     );
-    return {position: closestPoint.position, tangent: closestPoint.tangent};
+    return {
+      position: closestPoint.position,
+      tangent: closestPoint.tangent,
+      normal: closestPoint.tangent.perpendicular,
+    };
   }
 
   public transformPoints(matrix: DOMMatrix): Vector2[] {
@@ -72,7 +79,7 @@ export abstract class PolynomialSegment extends Segment {
     start = 0,
     end = 1,
     move = true,
-  ): [Vector2, Vector2, Vector2, Vector2] {
+  ): [CurvePoint, CurvePoint] {
     let curve: PolynomialSegment | null = null;
     let startT = start;
     let endT = end;
@@ -96,11 +103,20 @@ export abstract class PolynomialSegment extends Segment {
     }
     (curve ?? this).doDraw(context);
 
+    const startTangent = this.tangent(startT);
+    const endTangent = this.tangent(endT);
+
     return [
-      points[0],
-      this.tangent(startT),
-      points.at(-1)!,
-      this.tangent(endT),
+      {
+        position: points[0],
+        tangent: startTangent,
+        normal: startTangent.perpendicular,
+      },
+      {
+        position: points.at(-1)!,
+        tangent: endTangent,
+        normal: endTangent.perpendicular,
+      },
     ];
   }
 

--- a/packages/2d/src/curves/Segment.ts
+++ b/packages/2d/src/curves/Segment.ts
@@ -1,4 +1,3 @@
-import {Vector2} from '@motion-canvas/core/lib/types';
 import {CurvePoint} from './CurvePoint';
 
 export abstract class Segment {
@@ -7,7 +6,7 @@ export abstract class Segment {
     start: number,
     end: number,
     move: boolean,
-  ): [Vector2, Vector2, Vector2, Vector2];
+  ): [CurvePoint, CurvePoint];
 
   public abstract getPoint(distance: number): CurvePoint;
 

--- a/packages/2d/src/curves/getPointAtDistance.ts
+++ b/packages/2d/src/curves/getPointAtDistance.ts
@@ -18,5 +18,5 @@ export function getPointAtDistance(
     }
   }
 
-  return {position: Vector2.zero, tangent: Vector2.up};
+  return {position: Vector2.zero, tangent: Vector2.up, normal: Vector2.up};
 }


### PR DESCRIPTION
This PR does three things:

1. Add a `normal` property to `CurvePoint` that contains the normal of the point
2. Deprecate the `tangent` property of `CurvePoint` as it actually contains the normal of the point in a lot of cases.
3. Use the `normal` to calculate the actual tangent internally for now, e.g. when drawing arrow heads for lines and curves.

Tangents are kept as-is for now as changing them would be a breaking change. They will be fixed in the next major version.

This also fixes an inconsistent behavior in how arrow heads were drawn for linear and non-linear curves.

| Before | After |
| -------|------|
| <img width="460" alt="CleanShot 2023-03-30 at 08 20 18@2x" src="https://user-images.githubusercontent.com/5139098/228747613-3f7552ae-df2e-4f7b-bf58-a6e57a9f0de6.png"> | <img width="420" alt="CleanShot 2023-03-30 at 08 20 29@2x" src="https://user-images.githubusercontent.com/5139098/228747685-c9e5e760-ec61-43ee-b8e0-e0254ec482ba.png"> |