### PR TITLE
feat(docs): add snippet toggle for fiddles

### DIFF
--- a/packages/docs/docs/components/spline.mdx
+++ b/packages/docs/docs/components/spline.mdx
@@ -3,9 +3,6 @@ sidebar_position: 3
 slug: /spline
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Spline
 
 ```tsx editor
@@ -355,10 +352,8 @@ transformations.
 
 :::
 
-<Tabs>
-  <TabItem value='position' label='Position' default>
-
 ```tsx editor
+// snippet Position
 export default makeScene2D(function* (view) {
   const knotPositions: PossibleVector2[] = [
     [-200, 0],
@@ -383,13 +378,8 @@ export default makeScene2D(function* (view) {
     knots[3].position.y(80, 1).to(-80, 1),
   );
 });
-```
 
-  </TabItem>
-
-  <TabItem value="rotation" label="Rotation">
-
-```tsx editor
+// snippet Rotation
 export default makeScene2D(function* (view) {
   const knot = createRef<Knot>();
 
@@ -403,13 +393,8 @@ export default makeScene2D(function* (view) {
 
   yield* knot().rotation(360, 3, linear).to(0, 3);
 });
-```
 
-  </TabItem>
-
-  <TabItem value="scale" label="Scale">
-
-```tsx editor
+// snippet Scale
 export default makeScene2D(function* (view) {
   const knot = createRef<Knot>();
 
@@ -424,10 +409,6 @@ export default makeScene2D(function* (view) {
   yield* knot().scale(3, 2).to(0.2, 2).to(1, 1);
 });
 ```
-
-  </TabItem>
-
-</Tabs>
 
 ### Animating objects along a spline
 

--- a/packages/docs/src/components/Dropdown/index.tsx
+++ b/packages/docs/src/components/Dropdown/index.tsx
@@ -1,0 +1,95 @@
+import React, {useEffect, useRef, useState} from 'react';
+import clsx from 'clsx';
+
+export interface DropdownProps {
+  options: {
+    value: number;
+    name: string;
+  }[];
+  value: number;
+  className?: string;
+  onChange: (value: number) => void;
+}
+
+export default function Dropdown({
+  options,
+  value,
+  className,
+  onChange,
+}: DropdownProps) {
+  const ref = useRef<HTMLDivElement>();
+  const linkRef = useRef<HTMLAnchorElement>();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [ref]);
+
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        'dropdown dropdown--right',
+        open && 'dropdown--show',
+        className,
+      )}
+    >
+      <a
+        ref={linkRef}
+        className="navbar__link"
+        href="#"
+        onClick={event => {
+          event.preventDefault();
+          setOpen(!open);
+        }}
+      >
+        {options.find(option => option.value === value)?.name ?? value}
+      </a>
+      <ul className="dropdown__menu">
+        {options.map((option, index) => (
+          <li key={option.value}>
+            <a
+              href="#"
+              className={clsx(
+                'dropdown__link',
+                value === option.value && 'dropdown__link--active',
+              )}
+              onClick={event => {
+                event.preventDefault();
+                onChange(option.value);
+                setOpen(false);
+                linkRef.current.focus();
+              }}
+              onKeyDown={event => {
+                if (
+                  index === options.length - 1 &&
+                  event.key === 'Tab' &&
+                  !event.shiftKey
+                ) {
+                  event.preventDefault();
+                  setOpen(false);
+                  linkRef.current.focus();
+                }
+              }}
+            >
+              {option.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/docs/src/components/Fiddle/index.tsx
+++ b/packages/docs/src/components/Fiddle/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {basicSetup} from 'codemirror';
 import {EditorView, keymap} from '@codemirror/view';
 import {Text, EditorState} from '@codemirror/state';
@@ -27,6 +27,8 @@ import {
   transform,
   TransformError,
 } from '@site/src/components/Fiddle/transformer';
+import {parseFiddle} from '@site/src/components/Fiddle/parseFiddle';
+import Dropdown from '@site/src/components/Dropdown';
 
 export interface FiddleProps {
   children: string;
@@ -59,7 +61,6 @@ export default function Fiddle({children}: FiddleProps) {
 
   const [doc, setDoc] = useState<Text | null>(null);
   const [lastDoc, setLastDoc] = useState<Text | null>(null);
-  const [initialState, setInitialState] = useState<EditorState>(null);
 
   const update = (newDoc: Text, animate = true) => {
     borrowPlayer(setPlayer, previewRef.current);
@@ -73,40 +74,51 @@ export default function Fiddle({children}: FiddleProps) {
     }
   };
 
+  const [snippetId, setSnippetId] = useState(0);
+  const snippets = useMemo(
+    () =>
+      parseFiddle(children).map(snippet => ({
+        name: snippet.name,
+        state: EditorState.create({
+          doc: Text.of(snippet.lines),
+          extensions: [
+            basicSetup,
+            keymap.of([
+              indentWithTab,
+              {
+                key: 'Mod-s',
+                preventDefault: true,
+                run: view => {
+                  update(view.state.doc);
+                  return true;
+                },
+              },
+            ]),
+            EditorView.updateListener.of(update => {
+              setDoc(update.state.doc);
+              setError(null);
+            }),
+            autocomplete(),
+            javascript({
+              jsx: true,
+              typescript: true,
+            }),
+            syntaxHighlighting(SyntaxHighlightStyle),
+            EditorTheme,
+          ],
+        }),
+      })),
+    [children],
+  );
+
   useEffect(() => {
     editorView.current = new EditorView({
-      extensions: [
-        basicSetup,
-        keymap.of([
-          indentWithTab,
-          {
-            key: 'Mod-s',
-            preventDefault: true,
-            run: view => {
-              update(view.state.doc);
-              return true;
-            },
-          },
-        ]),
-        EditorView.updateListener.of(update => {
-          setDoc(update.state.doc);
-          setError(null);
-        }),
-        autocomplete(),
-        javascript({
-          jsx: true,
-          typescript: true,
-        }),
-        syntaxHighlighting(SyntaxHighlightStyle),
-        EditorTheme,
-      ],
       parent: editorRef.current,
-      doc: children,
+      state: snippets[snippetId].state,
     });
-    setInitialState(editorView.current.state);
     const borrowed = tryBorrowPlayer(setPlayer, previewRef.current);
     if (borrowed) {
-      update(editorView.current.state.doc, false);
+      update(snippets[snippetId].state.doc, false);
     }
 
     return () => {
@@ -114,6 +126,11 @@ export default function Fiddle({children}: FiddleProps) {
       editorView.current.destroy();
     };
   }, []);
+
+  const hasChangedSinceLastUpdate = lastDoc && doc && !doc.eq(lastDoc);
+  const hasChanged =
+    (doc && !doc.eq(snippets[snippetId].state.doc)) ||
+    hasChangedSinceLastUpdate;
 
   return (
     <div className={styles.root}>
@@ -126,7 +143,7 @@ export default function Fiddle({children}: FiddleProps) {
       />
       <div className={styles.controls}>
         <div className={styles.section}>
-          {lastDoc && !doc?.eq(lastDoc) && (
+          {hasChangedSinceLastUpdate && (
             <button
               onClick={() => update(editorView.current.state.doc)}
               className={styles.button}
@@ -169,25 +186,41 @@ export default function Fiddle({children}: FiddleProps) {
           </button>
         </div>
         <div className={styles.section}>
-          {((initialState && !doc?.eq(initialState.doc)) ||
-            (lastDoc && !doc?.eq(lastDoc))) && (
+          {snippets.length === 0 && hasChanged && (
             <button
               className={styles.button}
               onClick={() => {
-                editorView.current.setState(initialState);
-                update(initialState.doc);
-                setDoc(initialState.doc);
+                editorView.current.setState(snippets[snippetId].state);
+                update(snippets[snippetId].state.doc);
+                setDoc(snippets[snippetId].state.doc);
               }}
             >
               <small>Reset example</small>
             </button>
+          )}
+          {snippets.length > 1 && (
+            <Dropdown
+              className={styles.picker}
+              value={hasChanged ? -1 : snippetId}
+              onChange={id => {
+                setSnippetId(id);
+                editorView.current.setState(snippets[id].state);
+                update(snippets[id].state.doc);
+              }}
+              options={snippets
+                .map((snippet, index) => ({
+                  value: index,
+                  name: snippet.name,
+                }))
+                .concat(hasChanged ? {value: -1, name: 'Custom'} : [])}
+            />
           )}
         </div>
       </div>
       {error && <pre className={styles.error}>{error.message}</pre>}
       <div className={styles.editor} ref={editorRef}>
         <CodeBlock className={styles.source} language="tsx">
-          {children + '\n'}
+          {snippets[0].state.doc.toString() + '\n'}
         </CodeBlock>
       </div>
     </div>

--- a/packages/docs/src/components/Fiddle/parseFiddle.ts
+++ b/packages/docs/src/components/Fiddle/parseFiddle.ts
@@ -1,0 +1,46 @@
+export interface CodeSnippet {
+  name: string;
+  lines: string[];
+}
+
+const CommentRegex = / *\/\/ ?(\S+) ?(.*)/;
+
+const IgnoredComments = [
+  'highlight-next-line',
+  'highlight-start',
+  'highlight-end',
+];
+
+export function parseFiddle(code: string): CodeSnippet[] {
+  let snippet: CodeSnippet = {
+    name: 'Default',
+    lines: [],
+  };
+  const snippets = [snippet];
+  for (const line of code.split('\n')) {
+    const match = CommentRegex.exec(line);
+    if (!match) {
+      snippet.lines.push(line);
+      continue;
+    }
+
+    const [, comment, snippetName] = match;
+    if (IgnoredComments.includes(comment)) {
+      continue;
+    }
+
+    if (comment !== 'snippet') {
+      snippet.lines.push(line);
+      continue;
+    }
+
+    if (snippet.lines.length > 0) {
+      snippet = {name: snippetName, lines: []};
+      snippets.push(snippet);
+    } else {
+      snippet.name = snippetName;
+    }
+  }
+
+  return snippets;
+}

--- a/packages/docs/src/components/Fiddle/styles.module.css
+++ b/packages/docs/src/components/Fiddle/styles.module.css
@@ -21,18 +21,20 @@
 }
 
 .section {
-  width: 33.333%;
   display: flex;
   justify-content: center;
+  align-items: center;
   gap: 8px;
   padding: 8px;
 }
 
 .section:first-child {
+  flex-basis: 100%;
   justify-content: start;
 }
 
 .section:last-child {
+  flex-basis: 100%;
   justify-content: end;
 }
 


### PR DESCRIPTION
Fiddle editors can now include multiple snippets to choose from:
````md
```tsx editor
// snippet Example A
export default makeScene2D(function* (view) {
  // first example
}

// snippet Example B
export default makeScene2D(function* (view) {
  // another example
}
```
````
https://user-images.githubusercontent.com/64662184/228849190-916e5ff4-319a-4b6e-967b-e4ddf1002b96.mp4
