### PR TITLE
CodeBlock: re-setting the signal to its default

### DIFF
--- a/packages/docs/docs/components/code-block.mdx
+++ b/packages/docs/docs/components/code-block.mdx
@@ -150,7 +150,20 @@ yield * codeRef().selection(lines(1));
 yield * codeRef().selection(lines(1, 2));
 ```
 
-To remove a selection, you must set the selected range from `[0, 0]` to
+To remove a selection, the value of `.selection()` signal can be set to its
+[`DEFAULT`](signal-default), i.e. "all selected". For example:
+
+```ts
+import {DEFAULT} from '@motion-canvas/core/lib/signals';
+
+// highlight lines 1 and 2
+yield * codeRef().selection(lines(1, 2));
+
+// highlight all lines
+yield * codeRef().selection(DEFAULT);
+```
+
+Alternatively, the selected range can be set from `[0, 0]` to
 `[Infinity, Infinity]` to select all text. This is most easily performed by
 setting the selection to `lines(0, Infinity)`.
 
@@ -262,3 +275,4 @@ const myBool = true;
 ```
 
 [languages]: https://github.com/wooorm/starry-night#languages
+[signal-default]: /docs/signals#default-values


### PR DESCRIPTION
Mention an alternative way to de-select all text: it can be done by setting a value of `.selection()` signal to its default, e.g. "all selected".
