### PR TITLE
Typo in loop description

### DIFF
--- a/packages/core/src/flow/loop.ts
+++ b/packages/core/src/flow/loop.ts
@@ -30,7 +30,7 @@ decorate(loop, threadable());
  * yield* loop(
  *   colors.length,
  *   i => rect.fill(colors[i], 2),
- * });
+ * );
  * ```
  *
  * @param iterations - The number of iterations.


### PR DESCRIPTION
There is an extra brace in loop example function