### PR TITLE
fix(2d): fix curve arrow alignment when animating start signal

### DIFF
--- a/packages/2d/src/components/CubicBezier.ts
+++ b/packages/2d/src/components/CubicBezier.ts
@@ -8,21 +8,21 @@ import {bezierCurveTo, lineTo, moveTo} from '../utils';
 import {Bezier, BezierOverlayInfo} from './Bezier';
 
 export interface CubicBezierProps extends CurveProps {
-  p0: SignalValue<PossibleVector2>;
-  p0X: SignalValue<number>;
-  p0Y: SignalValue<number>;
+  p0?: SignalValue<PossibleVector2>;
+  p0X?: SignalValue<number>;
+  p0Y?: SignalValue<number>;
 
-  p1: SignalValue<PossibleVector2>;
-  p1X: SignalValue<number>;
-  p1Y: SignalValue<number>;
+  p1?: SignalValue<PossibleVector2>;
+  p1X?: SignalValue<number>;
+  p1Y?: SignalValue<number>;
 
-  p2: SignalValue<PossibleVector2>;
-  p2X: SignalValue<number>;
-  p2Y: SignalValue<number>;
+  p2?: SignalValue<PossibleVector2>;
+  p2X?: SignalValue<number>;
+  p2Y?: SignalValue<number>;
 
-  p3: SignalValue<PossibleVector2>;
-  p3X: SignalValue<number>;
-  p3Y: SignalValue<number>;
+  p3?: SignalValue<PossibleVector2>;
+  p3X?: SignalValue<number>;
+  p3Y?: SignalValue<number>;
 }
 
 /**

--- a/packages/2d/src/components/QuadBezier.ts
+++ b/packages/2d/src/components/QuadBezier.ts
@@ -8,17 +8,17 @@ import {Bezier, BezierOverlayInfo} from './Bezier';
 import {CurveProps} from './Curve';
 
 export interface QuadBezierProps extends CurveProps {
-  p0: SignalValue<PossibleVector2>;
-  p0X: SignalValue<number>;
-  p0Y: SignalValue<number>;
+  p0?: SignalValue<PossibleVector2>;
+  p0X?: SignalValue<number>;
+  p0Y?: SignalValue<number>;
 
-  p1: SignalValue<PossibleVector2>;
-  p1X: SignalValue<number>;
-  p1Y: SignalValue<number>;
+  p1?: SignalValue<PossibleVector2>;
+  p1X?: SignalValue<number>;
+  p1Y?: SignalValue<number>;
 
-  p2: SignalValue<PossibleVector2>;
-  p2X: SignalValue<number>;
-  p2Y: SignalValue<number>;
+  p2?: SignalValue<PossibleVector2>;
+  p2X?: SignalValue<number>;
+  p2Y?: SignalValue<number>;
 }
 
 /**

--- a/packages/2d/src/curves/PolynomialSegment.ts
+++ b/packages/2d/src/curves/PolynomialSegment.ts
@@ -91,10 +91,10 @@ export abstract class PolynomialSegment extends Segment {
 
       startT = this.pointSampler.distanceToT(startDistance);
       endT = this.pointSampler.distanceToT(endDistance);
-      endT = (endT - startT) / (1 - startT);
+      const relativeEndT = (endT - startT) / (1 - startT);
 
       const [, startSegment] = this.split(startT);
-      [curve] = startSegment.split(endT);
+      [curve] = startSegment.split(relativeEndT);
       points = curve.points;
     }
 


### PR DESCRIPTION
I also made the `p0X` signals on `CubicBezier` and `QuadBezier` optional because I forgot this last time 😇 