### PR TITLE
chore(docs): update docusaurus to suggested version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,74 +52,74 @@
       "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
-      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.17.0.tgz",
+      "integrity": "sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
-      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.17.0.tgz",
+      "integrity": "sha512-g8mXzkrcUBIPZaulAuqE7xyHhLAYAcF2xSch7d9dABheybaU3U91LjBX6eJTEB7XVhEsgK4Smi27vWtAJRhIKQ=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
-      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.17.0.tgz",
+      "integrity": "sha512-PT32ciC/xI8z919d0oknWVu3kMfTlhQn3MKxDln3pkn+yA7F7xrxSALysxquv+MhFfNAcrtQ/oVvQVBAQSHtdw==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
-      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.17.0.tgz",
+      "integrity": "sha512-sSEHx9GA6m7wrlsSMNBGfyzlIfDT2fkz2u7jqfCCd6JEEwmxt8emGmxAU/0qBfbhRSuGvzojoLJlr83BSZAKjA==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
-      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.17.0.tgz",
+      "integrity": "sha512-84ooP8QA3mQ958hQ9wozk7hFUbAO+81CX1CjAuerxBqjKIInh1fOhXKTaku05O/GHBvcfExpPLIQuSuLYziBXQ==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
-      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.17.0.tgz",
+      "integrity": "sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
-      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.17.0.tgz",
+      "integrity": "sha512-RMzN4dZLIta1YuwT7QC9o+OeGz2cU6eTOlGNE/6RcUBLOU3l9tkCOdln5dPE2jp8GZXPl2yk54b2nSs1+pAjqw==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
-      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.17.0.tgz",
+      "integrity": "sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -128,47 +128,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
-      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.17.0.tgz",
+      "integrity": "sha512-DGuoZqpTmIKJFDeyAJ7M8E/LOenIjWiOsg1XJ1OqAU/eofp49JfqXxbfgctlVZVmDABIyOz8LqEoJ6ZP4DTyvw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
-      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.17.0.tgz",
+      "integrity": "sha512-zMPvugQV/gbXUvWBCzihw6m7oxIKp48w37QBIUu/XqQQfxhjoOE9xyfJr1KldUt5FrYOKZJVsJaEjTsu+bIgQg==",
       "dependencies": {
-        "@algolia/logger-common": "4.14.3"
+        "@algolia/logger-common": "4.17.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
-      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.17.0.tgz",
+      "integrity": "sha512-aSOX/smauyTkP21Pf52pJ1O2LmNFJ5iHRIzEeTh0mwBeADO4GdG94cAWDILFA9rNblq/nK3EDh3+UyHHjplZ1A==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
-      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.17.0.tgz",
+      "integrity": "sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
-      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.17.0.tgz",
+      "integrity": "sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
-      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.17.0.tgz",
+      "integrity": "sha512-6xL6H6fe+Fi0AEP3ziSgC+G04RK37iRb4uUUqVAH9WPYFI8g+LYFq6iv5HS8Cbuc5TTut+Bwj6G+dh/asdb9uA==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1794,10 +1794,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.9",
-      "license": "MIT",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2253,9 +2254,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2267,13 +2268,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/cssnano-preset": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2349,9 +2350,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
+      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2363,9 +2364,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
-      "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
+      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2375,14 +2376,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
-      "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
+      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2406,12 +2407,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
+        "@docusaurus/types": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2425,17 +2426,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz",
-      "integrity": "sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
+      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2455,17 +2456,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
-      "integrity": "sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2485,15 +2486,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
-      "integrity": "sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
+      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2507,13 +2508,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
-      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
+      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2527,13 +2528,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
-      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
+      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2545,13 +2546,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
-      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2563,13 +2564,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
-      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
+      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2581,16 +2582,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
-      "integrity": "sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
+      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2604,23 +2605,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
-      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
+      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/plugin-debug": "2.3.1",
-        "@docusaurus/plugin-google-analytics": "2.3.1",
-        "@docusaurus/plugin-google-gtag": "2.3.1",
-        "@docusaurus/plugin-google-tag-manager": "2.3.1",
-        "@docusaurus/plugin-sitemap": "2.3.1",
-        "@docusaurus/theme-classic": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-search-algolia": "2.3.1",
-        "@docusaurus/types": "2.3.1"
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/plugin-debug": "2.4.0",
+        "@docusaurus/plugin-google-analytics": "2.4.0",
+        "@docusaurus/plugin-google-gtag": "2.4.0",
+        "@docusaurus/plugin-google-tag-manager": "2.4.0",
+        "@docusaurus/plugin-sitemap": "2.4.0",
+        "@docusaurus/theme-classic": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-search-algolia": "2.4.0",
+        "@docusaurus/types": "2.4.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -2642,26 +2643,26 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz",
-      "integrity": "sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
+      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
+        "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.14",
@@ -2681,16 +2682,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
-      "integrity": "sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
+      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2710,15 +2712,15 @@
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-2.3.1.tgz",
-      "integrity": "sha512-Hh1I4FSt+5qlrq6dBOgj/klv2Ijmzbn0ysa5XMDHeD6Fa3fK63vvf0KJMR6VzB9VHU8QjMqqAR+n9500/Kq4lw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-2.4.0.tgz",
+      "integrity": "sha512-qB4cMDn93iwQ5JzhLgHsME5DgUbISMKgk6nP6tEWqepP3S/WXR1L/uRAH8xXbuRhJgzERHM/f6riyv0cNIQeTg==",
       "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "mermaid": "^9.2.2",
         "tslib": "^2.4.0"
@@ -2732,18 +2734,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
-      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
+      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2762,9 +2764,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz",
-      "integrity": "sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2774,9 +2776,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2801,11 +2803,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
-      "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
       "dependencies": {
-        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
         "@svgr/webpack": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2835,9 +2837,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
-      "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
+      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2854,12 +2856,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
-      "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
+      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
       "dependencies": {
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -6532,9 +6534,9 @@
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-      "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
+      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -7361,30 +7363,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
-      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.17.0.tgz",
+      "integrity": "sha512-JMRh2Mw6sEnVMiz6+APsi7lx9a2jiDFF+WUtANaUVCv6uSU9UOLdo5h9K3pdP6frRRybaM2fX8b1u0nqICS9aA==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.3",
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/cache-in-memory": "4.14.3",
-        "@algolia/client-account": "4.14.3",
-        "@algolia/client-analytics": "4.14.3",
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-personalization": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/logger-console": "4.14.3",
-        "@algolia/requester-browser-xhr": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/requester-node-http": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/cache-browser-local-storage": "4.17.0",
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/cache-in-memory": "4.17.0",
+        "@algolia/client-account": "4.17.0",
+        "@algolia/client-analytics": "4.17.0",
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-personalization": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/logger-console": "4.17.0",
+        "@algolia/requester-browser-xhr": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/requester-node-http": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz",
-      "integrity": "sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
+      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -8397,7 +8399,8 @@
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dependencies": {
         "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
@@ -8660,9 +8663,9 @@
       }
     },
     "node_modules/cheerio/node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -8672,9 +8675,9 @@
       ],
       "dependencies": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "node_modules/chokidar": {
@@ -9384,9 +9387,9 @@
       "license": "MIT"
     },
     "node_modules/copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
       "engines": {
         "node": ">=12"
       },
@@ -9746,12 +9749,12 @@
       }
     },
     "node_modules/cssnano-preset-advanced": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.9.tgz",
-      "integrity": "sha512-njnh4pp1xCsibJcEHnWZb4EEzni0ePMqPuPNyuWT4Z+YeXmsgqNuTPIljXFEXhxGsWs9183JkXgHxc1TcsahIg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.10.tgz",
+      "integrity": "sha512-fnYJyCS9jgMU+cmHO1rPSPf9axbQyD7iUhLO5Df6O4G+fKIOMps+ZbU0PdGFejFBBZ3Pftf18fn1eG7MAPUSWQ==",
       "dependencies": {
         "autoprefixer": "^10.4.12",
-        "cssnano-preset-default": "^5.2.13",
+        "cssnano-preset-default": "^5.2.14",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -9765,20 +9768,21 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.2.13",
-      "license": "MIT",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
+      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
       "dependencies": {
         "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.0",
+        "postcss-colormin": "^5.3.1",
         "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
         "postcss-merge-longhand": "^5.1.7",
-        "postcss-merge-rules": "^5.1.3",
+        "postcss-merge-rules": "^5.1.4",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
         "postcss-minify-params": "^5.1.4",
@@ -9793,7 +9797,7 @@
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.1",
+        "postcss-reduce-initial": "^5.1.2",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -11783,9 +11787,9 @@
       "license": "ISC"
     },
     "node_modules/flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "dependencies": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -13159,9 +13163,9 @@
       "dev": true
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==",
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
       "engines": {
         "node": ">=12"
       }
@@ -15039,7 +15043,8 @@
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -17423,10 +17428,11 @@
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "5.3.0",
-      "license": "MIT",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
+      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "colord": "^2.9.1",
         "postcss-value-parser": "^4.2.0"
@@ -17556,8 +17562,9 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.1.3",
-      "license": "MIT",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
+      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
       "dependencies": {
         "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
@@ -17823,8 +17830,9 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "5.1.1",
-      "license": "MIT",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
+      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
       "dependencies": {
         "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
@@ -18567,11 +18575,11 @@
       "license": "MIT"
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
-      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       },
@@ -18964,8 +18972,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "license": "MIT"
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -20817,7 +20826,8 @@
     "node_modules/trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="
+      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
+      "deprecated": "Use String.prototype.trim() instead"
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
@@ -21052,9 +21062,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
       "funding": [
         {
           "type": "opencollective",
@@ -22693,10 +22703,10 @@
       "dependencies": {
         "@babel/standalone": "^7.21.3",
         "@codemirror/lang-javascript": "^6.1.4",
-        "@docusaurus/core": "^2.3.1",
-        "@docusaurus/preset-classic": "^2.3.1",
-        "@docusaurus/theme-mermaid": "^2.3.1",
-        "@docusaurus/theme-search-algolia": "^2.3.1",
+        "@docusaurus/core": "^2.4.0",
+        "@docusaurus/preset-classic": "^2.4.0",
+        "@docusaurus/theme-mermaid": "^2.4.0",
+        "@docusaurus/theme-search-algolia": "^2.4.0",
         "@mdx-js/react": "^1.6.22",
         "@motion-canvas/examples": "*",
         "@motion-canvas/player": "*",
@@ -22708,7 +22718,7 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^2.3.1",
+        "@docusaurus/module-type-aliases": "^2.4.0",
         "@tsconfig/docusaurus": "^1.0.5",
         "mdn-links": "^0.1.0",
         "typedoc": "^0.23.21",
@@ -22835,74 +22845,74 @@
       "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
-      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.17.0.tgz",
+      "integrity": "sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
-      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.17.0.tgz",
+      "integrity": "sha512-g8mXzkrcUBIPZaulAuqE7xyHhLAYAcF2xSch7d9dABheybaU3U91LjBX6eJTEB7XVhEsgK4Smi27vWtAJRhIKQ=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
-      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.17.0.tgz",
+      "integrity": "sha512-PT32ciC/xI8z919d0oknWVu3kMfTlhQn3MKxDln3pkn+yA7F7xrxSALysxquv+MhFfNAcrtQ/oVvQVBAQSHtdw==",
       "requires": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "@algolia/client-account": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
-      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.17.0.tgz",
+      "integrity": "sha512-sSEHx9GA6m7wrlsSMNBGfyzlIfDT2fkz2u7jqfCCd6JEEwmxt8emGmxAU/0qBfbhRSuGvzojoLJlr83BSZAKjA==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
-      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.17.0.tgz",
+      "integrity": "sha512-84ooP8QA3mQ958hQ9wozk7hFUbAO+81CX1CjAuerxBqjKIInh1fOhXKTaku05O/GHBvcfExpPLIQuSuLYziBXQ==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
-      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.17.0.tgz",
+      "integrity": "sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==",
       "requires": {
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
-      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.17.0.tgz",
+      "integrity": "sha512-RMzN4dZLIta1YuwT7QC9o+OeGz2cU6eTOlGNE/6RcUBLOU3l9tkCOdln5dPE2jp8GZXPl2yk54b2nSs1+pAjqw==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-search": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
-      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.17.0.tgz",
+      "integrity": "sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/events": {
@@ -22911,47 +22921,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
-      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.17.0.tgz",
+      "integrity": "sha512-DGuoZqpTmIKJFDeyAJ7M8E/LOenIjWiOsg1XJ1OqAU/eofp49JfqXxbfgctlVZVmDABIyOz8LqEoJ6ZP4DTyvw=="
     },
     "@algolia/logger-console": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
-      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.17.0.tgz",
+      "integrity": "sha512-zMPvugQV/gbXUvWBCzihw6m7oxIKp48w37QBIUu/XqQQfxhjoOE9xyfJr1KldUt5FrYOKZJVsJaEjTsu+bIgQg==",
       "requires": {
-        "@algolia/logger-common": "4.14.3"
+        "@algolia/logger-common": "4.17.0"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
-      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.17.0.tgz",
+      "integrity": "sha512-aSOX/smauyTkP21Pf52pJ1O2LmNFJ5iHRIzEeTh0mwBeADO4GdG94cAWDILFA9rNblq/nK3EDh3+UyHHjplZ1A==",
       "requires": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
-      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.17.0.tgz",
+      "integrity": "sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
-      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.17.0.tgz",
+      "integrity": "sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==",
       "requires": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "@algolia/transporter": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
-      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.17.0.tgz",
+      "integrity": "sha512-6xL6H6fe+Fi0AEP3ziSgC+G04RK37iRb4uUUqVAH9WPYFI8g+LYFq6iv5HS8Cbuc5TTut+Bwj6G+dh/asdb9uA==",
       "requires": {
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "@ampproject/remapping": {
@@ -23885,9 +23895,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.9",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -24217,9 +24229,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -24231,13 +24243,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/cssnano-preset": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -24302,9 +24314,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
+      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -24313,23 +24325,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
-      "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
+      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
-      "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
+      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -24346,12 +24358,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
+        "@docusaurus/types": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -24361,17 +24373,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz",
-      "integrity": "sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
+      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -24384,17 +24396,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
-      "integrity": "sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -24407,100 +24419,100 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
-      "integrity": "sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
+      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
-      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
+      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
-      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
+      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
-      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
-      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
+      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
-      "integrity": "sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
+      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
-      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
+      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/plugin-debug": "2.3.1",
-        "@docusaurus/plugin-google-analytics": "2.3.1",
-        "@docusaurus/plugin-google-gtag": "2.3.1",
-        "@docusaurus/plugin-google-tag-manager": "2.3.1",
-        "@docusaurus/plugin-sitemap": "2.3.1",
-        "@docusaurus/theme-classic": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-search-algolia": "2.3.1",
-        "@docusaurus/types": "2.3.1"
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/plugin-debug": "2.4.0",
+        "@docusaurus/plugin-google-analytics": "2.4.0",
+        "@docusaurus/plugin-google-gtag": "2.4.0",
+        "@docusaurus/plugin-google-tag-manager": "2.4.0",
+        "@docusaurus/plugin-sitemap": "2.4.0",
+        "@docusaurus/theme-classic": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-search-algolia": "2.4.0",
+        "@docusaurus/types": "2.4.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -24511,26 +24523,26 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz",
-      "integrity": "sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
+      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
+        "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.14",
@@ -24543,16 +24555,17 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
-      "integrity": "sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
+      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -24565,33 +24578,33 @@
       }
     },
     "@docusaurus/theme-mermaid": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-2.3.1.tgz",
-      "integrity": "sha512-Hh1I4FSt+5qlrq6dBOgj/klv2Ijmzbn0ysa5XMDHeD6Fa3fK63vvf0KJMR6VzB9VHU8QjMqqAR+n9500/Kq4lw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-2.4.0.tgz",
+      "integrity": "sha512-qB4cMDn93iwQ5JzhLgHsME5DgUbISMKgk6nP6tEWqepP3S/WXR1L/uRAH8xXbuRhJgzERHM/f6riyv0cNIQeTg==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "mermaid": "^9.2.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
-      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
+      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -24603,18 +24616,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz",
-      "integrity": "sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -24634,11 +24647,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
-      "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
       "requires": {
-        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
         "@svgr/webpack": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -24657,20 +24670,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
-      "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
+      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
-      "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
+      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
       "requires": {
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -26452,11 +26465,11 @@
       "requires": {
         "@babel/standalone": "^7.21.3",
         "@codemirror/lang-javascript": "^6.1.4",
-        "@docusaurus/core": "^2.3.1",
-        "@docusaurus/module-type-aliases": "^2.3.1",
-        "@docusaurus/preset-classic": "^2.3.1",
-        "@docusaurus/theme-mermaid": "^2.3.1",
-        "@docusaurus/theme-search-algolia": "^2.3.1",
+        "@docusaurus/core": "^2.4.0",
+        "@docusaurus/module-type-aliases": "^2.4.0",
+        "@docusaurus/preset-classic": "^2.4.0",
+        "@docusaurus/theme-mermaid": "^2.4.0",
+        "@docusaurus/theme-search-algolia": "^2.4.0",
         "@mdx-js/react": "^1.6.22",
         "@motion-canvas/examples": "*",
         "@motion-canvas/player": "*",
@@ -27432,9 +27445,9 @@
       "version": "7.0.11"
     },
     "@types/mdast": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-      "integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
+      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
       "requires": {
         "@types/unist": "*"
       }
@@ -28048,30 +28061,30 @@
       }
     },
     "algoliasearch": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
-      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.17.0.tgz",
+      "integrity": "sha512-JMRh2Mw6sEnVMiz6+APsi7lx9a2jiDFF+WUtANaUVCv6uSU9UOLdo5h9K3pdP6frRRybaM2fX8b1u0nqICS9aA==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.14.3",
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/cache-in-memory": "4.14.3",
-        "@algolia/client-account": "4.14.3",
-        "@algolia/client-analytics": "4.14.3",
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-personalization": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/logger-console": "4.14.3",
-        "@algolia/requester-browser-xhr": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/requester-node-http": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/cache-browser-local-storage": "4.17.0",
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/cache-in-memory": "4.17.0",
+        "@algolia/client-account": "4.17.0",
+        "@algolia/client-analytics": "4.17.0",
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-personalization": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/logger-console": "4.17.0",
+        "@algolia/requester-browser-xhr": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/requester-node-http": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz",
-      "integrity": "sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
+      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -28709,6 +28722,8 @@
     },
     "caniuse-api": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "requires": {
         "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
@@ -28819,14 +28834,14 @@
           "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
         },
         "htmlparser2": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-          "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
           "requires": {
             "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
+            "domhandler": "^5.0.3",
             "domutils": "^3.0.1",
-            "entities": "^4.3.0"
+            "entities": "^4.4.0"
           }
         }
       }
@@ -29364,9 +29379,9 @@
       "version": "1.0.6"
     },
     "copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng=="
     },
     "copy-webpack-plugin": {
       "version": "11.0.0",
@@ -29553,12 +29568,12 @@
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.9.tgz",
-      "integrity": "sha512-njnh4pp1xCsibJcEHnWZb4EEzni0ePMqPuPNyuWT4Z+YeXmsgqNuTPIljXFEXhxGsWs9183JkXgHxc1TcsahIg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.10.tgz",
+      "integrity": "sha512-fnYJyCS9jgMU+cmHO1rPSPf9axbQyD7iUhLO5Df6O4G+fKIOMps+ZbU0PdGFejFBBZ3Pftf18fn1eG7MAPUSWQ==",
       "requires": {
         "autoprefixer": "^10.4.12",
-        "cssnano-preset-default": "^5.2.13",
+        "cssnano-preset-default": "^5.2.14",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -29566,19 +29581,21 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.2.13",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
+      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
       "requires": {
         "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.0",
+        "postcss-colormin": "^5.3.1",
         "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
         "postcss-merge-longhand": "^5.1.7",
-        "postcss-merge-rules": "^5.1.3",
+        "postcss-merge-rules": "^5.1.4",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
         "postcss-minify-params": "^5.1.4",
@@ -29593,7 +29610,7 @@
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.1",
+        "postcss-reduce-initial": "^5.1.2",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -30901,9 +30918,9 @@
       "devOptional": true
     },
     "flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "requires": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -31804,9 +31821,9 @@
       "dev": true
     },
     "infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww=="
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -33052,7 +33069,9 @@
       "dev": true
     },
     "lodash.memoize": {
-      "version": "4.1.2"
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -34680,9 +34699,11 @@
       }
     },
     "postcss-colormin": {
-      "version": "5.3.0",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
+      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "colord": "^2.9.1",
         "postcss-value-parser": "^4.2.0"
@@ -34744,7 +34765,9 @@
       }
     },
     "postcss-merge-rules": {
-      "version": "5.1.3",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
+      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
       "requires": {
         "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
@@ -34874,7 +34897,9 @@
       }
     },
     "postcss-reduce-initial": {
-      "version": "5.1.1",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
+      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
       "requires": {
         "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
@@ -35369,11 +35394,11 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
-      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       }
@@ -35673,7 +35698,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9"
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -37062,9 +37089,9 @@
       "version": "4.9.5"
     },
     "ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g=="
     },
     "ufo": {
       "version": "1.1.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -18,10 +18,10 @@
   "dependencies": {
     "@babel/standalone": "^7.21.3",
     "@codemirror/lang-javascript": "^6.1.4",
-    "@docusaurus/core": "^2.3.1",
-    "@docusaurus/preset-classic": "^2.3.1",
-    "@docusaurus/theme-mermaid": "^2.3.1",
-    "@docusaurus/theme-search-algolia": "^2.3.1",
+    "@docusaurus/core": "^2.4.0",
+    "@docusaurus/preset-classic": "^2.4.0",
+    "@docusaurus/theme-mermaid": "^2.4.0",
+    "@docusaurus/theme-search-algolia": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
     "@motion-canvas/examples": "*",
     "@motion-canvas/player": "*",
@@ -33,7 +33,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.3.1",
+    "@docusaurus/module-type-aliases": "^2.4.0",
     "@tsconfig/docusaurus": "^1.0.5",
     "mdn-links": "^0.1.0",
     "typedoc": "^0.23.21",


### PR DESCRIPTION
Running `npm run docs:start` is rendering a banner suggesting the following command to be executed to upgrade the docusaurus family of packages:

```
npm i \
  @docusaurus/core@latest \
  @docusaurus/preset-classic@latest \
  @docusaurus/theme-mermaid@latest \
  @docusaurus/theme-search-algolia@latest \
  @docusaurus/module-type-aliases@latest
```

~I am not exactly certain why changes related to docusaurs package version appear in `package.json` file - suggests docusaurus should probably be updated differently? 🤔 But I decided to open a PR anyone to at least start a discussion about this.~ Re-ran this same command inside `packages/docs`.