### PR TITLE
feat(core): add `loopUntil` function for V3

### DIFF
--- a/packages/core/src/flow/index.ts
+++ b/packages/core/src/flow/index.ts
@@ -9,6 +9,7 @@ export * from './chain';
 export * from './delay';
 export * from './every';
 export * from './loop';
+export * from './loopUntil';
 export * from './noop';
 export * from './run';
 export * from './scheduling';

--- a/packages/core/src/flow/loopUntil.ts
+++ b/packages/core/src/flow/loopUntil.ts
@@ -1,0 +1,40 @@
+import {useDuration, usePlayback, useThread} from '../utils';
+import {decorate, threadable} from '../decorators';
+import {ThreadGenerator} from '../threading';
+import {LoopCallback} from './loop';
+
+decorate(loopUntil, threadable());
+/**
+ * Run the given generator until an event occurs.
+ *
+ * @example
+ * ```ts
+ * yield* loopUntil(
+ *   'Stop Looping',
+ *   () => circle().position.x(-10, 0.1).to(10, 0.1)
+ * );
+ * ```
+ *
+ * @param event - The event.
+ * @param tasks - A list of tasks to run.
+ */
+export function* loopUntil(
+  event: string,
+  factory: LoopCallback,
+): ThreadGenerator {
+  const thread = useThread();
+  const step = usePlayback().framesToSeconds(1);
+  const targetTime = thread.time() + useDuration(event);
+
+  let iteration = 0;
+  while (targetTime - step > thread.fixed) {
+    const generator = factory(iteration);
+    if (generator) {
+      yield* generator;
+    } else {
+      yield;
+    }
+    iteration += 1;
+  }
+  thread.time(targetTime);
+}

--- a/packages/core/src/flow/loopUntil.ts
+++ b/packages/core/src/flow/loopUntil.ts
@@ -16,7 +16,8 @@ decorate(loopUntil, threadable());
  * ```
  *
  * @param event - The event.
- * @param tasks - A list of tasks to run.
+ * @param factory - A function creating the generator to run. Because generators
+ *                can't be reset, a new generator is created on each iteration.
  */
 export function* loopUntil(
   event: string,


### PR DESCRIPTION
**Summary**
This PR closes #362 by implementing a `loopUntil()` function. It works in a way similar to `loop()` but uses a `TimeEvent` rather than `iterations` to control the loop. It is now fully updated to work with Motion Canvas version 3 or above.

**Functionality**
This functionality can be achieved by threads, however these are currently undocumented and the approach of adding a new `flow` function would make the process more intuitive for beginners. I followed the naming conventions, and would have renamed `loop()` to `loopFor()` to follow the names of `waitFor()` and `waitUntil()` however this would introduce breaking changes to projects currently using `loop()`.

**Example usage**
```tsx
const circle = createRef<Circle>();

view.add(
	<Circle ref={circle} width={320} height={320} fill={'lightseagreen'} />,
);

yield* loopUntil(  // Perform `circle().position.x(-10,0.1).to(10,0.1)` repeatedly until 'endVibrate' event
	'endVibrate', () =>
	circle().position.x(-10,0.1).to(10,0.1),
);
```