### PR TITLE
feat(2d): Node.addTo method

### DIFF
--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -555,6 +555,34 @@ export class Node implements Promisable<Node> {
     return this.insert(node, Infinity);
   }
 
+
+  /**
+   * Add this node as a child of another node.
+   *
+   * @remarks
+   * This node will be appended at the end of the children list of the another node.
+   *
+   * @example
+   * ```tsx
+   * const rect = <Rect />;
+   * const node = <Layout />;
+   * rect.addTo(node);
+   * ```
+   * Result:
+   * ```mermaid
+   * graph TD;
+   *   layout([Layout])
+   *   rect([Rect])
+   *     layout-->rect;
+   * ```
+   *
+   * @param node - A node or an array of nodes to append.
+   */
+  public addTo(node: Node): this {
+    node.add(this);
+    return this;
+  }
+
   /**
    * Insert the given node(s) at the specified index in the children list.
    *

--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -555,7 +555,6 @@ export class Node implements Promisable<Node> {
     return this.insert(node, Infinity);
   }
 
-
   /**
    * Add this node as a child of another node.
    *


### PR DESCRIPTION
Trivial addition.

`Node.add` now has a sister method, `Node.addTo` - simply calls `.add` on a different node.

Good for chaining methods, and for people writing helper libraries.
I had the idea because of a something I'm working on ([ccaven/processing-motion-canvas](
https://github.com/ccaven/processing-motion-canvas))

Example:
```tsx
this.nodeStack().shift().addTo(this.getRoot());
```