### PR TITLE
feat(2d): add ref method on node class

### DIFF
--- a/packages/2d/src/components/Node.ts
+++ b/packages/2d/src/components/Node.ts
@@ -25,6 +25,8 @@ import {
   DetailedError,
   ReferenceReceiver,
   useLogger,
+  createRef,
+  Reference,
 } from '@motion-canvas/core/lib/utils';
 import type {ComponentChild, ComponentChildren, NodeConstructor} from './types';
 import {Promisable} from '@motion-canvas/core/lib/threading';
@@ -1280,6 +1282,18 @@ export class Node implements Promisable<Node> {
       promises = DependencyContext.consumePromises();
     } while (promises.length > 0);
     return this;
+  }
+
+  /**
+   * Create and return a reference for this node.
+   *
+   * @remarks
+   * This method creates a new Reference object for this node.
+   */
+  public ref(): Reference<this> {
+    const ref = createRef<typeof this>();
+    ref(this);
+    return ref;
   }
 
   /**


### PR DESCRIPTION
Trivial change.

Adds a method, `ref() => Reference<this>` on the `Node` class.

Use case:
```tsx
return this.nodeStack.shift().ref(); // this.nodeStack is a Node[]
```