### PR TITLE
feat(2d): add Ray node

### DIFF
--- a/packages/2d/src/components/Bezier.ts
+++ b/packages/2d/src/components/Bezier.ts
@@ -3,7 +3,7 @@ import {Curve} from './Curve';
 import {CurveProfile} from '../curves';
 import {PolynomialSegment} from '../curves/PolynomialSegment';
 import {DesiredLength} from '../partials';
-import {arc, drawLine, lineTo, moveTo} from '../utils';
+import {arc, drawLine, drawPivot, moveTo} from '../utils';
 import {computed} from '../decorators';
 
 export interface BezierOverlayInfo {
@@ -90,13 +90,8 @@ export abstract class Bezier extends Curve {
 
     // Draw the offset marker
     context.lineWidth = 1;
-    const radius = 8;
     context.beginPath();
-    lineTo(context, offset.addY(-radius));
-    lineTo(context, offset.addY(radius));
-    lineTo(context, offset);
-    lineTo(context, offset.addX(-radius));
-    context.arc(offset.x, offset.y, radius, 0, Math.PI * 2);
+    drawPivot(context, offset);
     context.stroke();
 
     // Draw the bounding box

--- a/packages/2d/src/components/Layout.ts
+++ b/packages/2d/src/components/Layout.ts
@@ -39,7 +39,7 @@ import {
 import {threadable} from '@motion-canvas/core/lib/decorators';
 import {ThreadGenerator} from '@motion-canvas/core/lib/threading';
 import {Node, NodeProps} from './Node';
-import {drawLine, lineTo} from '../utils';
+import {drawLine, drawPivot} from '../utils';
 import {spacingSignal} from '../decorators/spacingSignal';
 import {
   createSignal,
@@ -675,13 +675,8 @@ export class Layout extends Node {
     context.strokeStyle = 'white';
     context.stroke();
 
-    const radius = 8;
     context.beginPath();
-    lineTo(context, offset.addY(-radius));
-    lineTo(context, offset.addY(radius));
-    lineTo(context, offset);
-    lineTo(context, offset.addX(-radius));
-    context.arc(offset.x, offset.y, radius, 0, Math.PI * 2);
+    drawPivot(context, offset);
     context.stroke();
   }
 

--- a/packages/2d/src/components/Line.ts
+++ b/packages/2d/src/components/Line.ts
@@ -7,7 +7,7 @@ import {BBox, PossibleVector2, Vector2} from '@motion-canvas/core/lib/types';
 import {useLogger} from '@motion-canvas/core/lib/utils';
 import {CurveProfile, getPolylineProfile} from '../curves';
 import {computed, initial, signal} from '../decorators';
-import {arc, drawLine, lineTo, moveTo} from '../utils';
+import {arc, drawLine, drawPivot, lineTo, moveTo} from '../utils';
 import {Curve, CurveProps} from './Curve';
 import {Layout} from './Layout';
 import lineWithoutPoints from './__logs__/line-without-points.md';
@@ -121,13 +121,8 @@ export class Line extends Curve {
     context.strokeStyle = 'white';
     context.stroke(path);
 
-    const radius = 8;
     context.beginPath();
-    lineTo(context, offset.addY(-radius));
-    lineTo(context, offset.addY(radius));
-    lineTo(context, offset);
-    lineTo(context, offset.addX(-radius));
-    context.arc(offset.x, offset.y, radius, 0, Math.PI * 2);
+    drawPivot(context, offset);
     context.stroke();
 
     context.beginPath();

--- a/packages/2d/src/components/Ray.ts
+++ b/packages/2d/src/components/Ray.ts
@@ -1,0 +1,127 @@
+import {SignalValue} from '@motion-canvas/core/lib/signals';
+import {
+  BBox,
+  PossibleVector2,
+  Vector2Signal,
+} from '@motion-canvas/core/lib/types';
+import {CurveProfile, LineSegment} from '../curves';
+import {computed, vector2Signal} from '../decorators';
+import {arc, drawLine, drawPivot} from '../utils';
+import {Curve, CurveProps} from './Curve';
+
+export interface RayProps extends CurveProps {
+  /**
+   * {@inheritDoc Ray.from}
+   */
+  from?: SignalValue<PossibleVector2>;
+  fromX?: SignalValue<number>;
+  fromY?: SignalValue<number>;
+
+  /**
+   * {@inheritDoc Ray.to}
+   */
+  to?: SignalValue<PossibleVector2>;
+  toX?: SignalValue<number>;
+  toY?: SignalValue<number>;
+}
+
+/**
+ * A node for drawing an individual line segment.
+ *
+ * @preview
+ * ```tsx editor
+ * import {makeScene2D} from '@motion-canvas/2d';
+ * import {Ray} from '@motion-canvas/2d/lib/components';
+ * import {createRef} from '@motion-canvas/core/lib/utils';
+ *
+ * export default makeScene2D(function* (view) {
+ *   const ray = createRef<Ray>();
+ *
+ *   view.add(
+ *     <Ray
+ *       ref={ray}
+ *       lineWidth={8}
+ *       endArrow
+ *       stroke={'lightseagreen'}
+ *       fromX={-200}
+ *       toX={200}
+ *     />,
+ *   );
+ *
+ *   yield* ray().start(1, 1);
+ *   yield* ray().start(0).end(0).start(1, 1);
+ * });
+ * ```
+ */
+export class Ray extends Curve {
+  /**
+   * The starting point of the ray.
+   */
+  @vector2Signal('from')
+  public declare readonly from: Vector2Signal<this>;
+
+  /**
+   * The ending point of the ray.
+   */
+  @vector2Signal('to')
+  public declare readonly to: Vector2Signal<this>;
+
+  public constructor(props: RayProps) {
+    super(props);
+  }
+
+  @computed()
+  protected override childrenBBox() {
+    return BBox.fromPoints(this.from(), this.to());
+  }
+
+  @computed()
+  public override profile(): CurveProfile {
+    const segment = new LineSegment(this.from(), this.to());
+
+    return {
+      arcLength: segment.arcLength,
+      minSin: 1,
+      segments: [segment],
+    };
+  }
+
+  public override drawOverlay(
+    context: CanvasRenderingContext2D,
+    matrix: DOMMatrix,
+  ) {
+    const box = this.childrenBBox().transformCorners(matrix);
+    const size = this.computedSize();
+    const offset = size.mul(this.offset()).scale(0.5).transformAsPoint(matrix);
+    const from = this.from().transformAsPoint(matrix);
+    const to = this.to().transformAsPoint(matrix);
+
+    context.fillStyle = 'white';
+    context.strokeStyle = 'black';
+    context.lineWidth = 1;
+
+    context.beginPath();
+    arc(context, from, 4);
+    context.fill();
+    context.stroke();
+
+    context.beginPath();
+    arc(context, to, 4);
+    context.fill();
+    context.stroke();
+
+    context.strokeStyle = 'white';
+    context.beginPath();
+    drawLine(context, [from, to]);
+    context.stroke();
+
+    context.beginPath();
+    drawPivot(context, offset);
+    context.stroke();
+
+    context.beginPath();
+    drawLine(context, box);
+    context.closePath();
+    context.stroke();
+  }
+}

--- a/packages/2d/src/components/Ray.ts
+++ b/packages/2d/src/components/Ray.ts
@@ -5,7 +5,7 @@ import {
   Vector2Signal,
 } from '@motion-canvas/core/lib/types';
 import {CurveProfile, LineSegment} from '../curves';
-import {computed, vector2Signal} from '../decorators';
+import {vector2Signal} from '../decorators';
 import {arc, drawLine, drawPivot} from '../utils';
 import {Curve, CurveProps} from './Curve';
 
@@ -70,12 +70,10 @@ export class Ray extends Curve {
     super(props);
   }
 
-  @computed()
   protected override childrenBBox() {
     return BBox.fromPoints(this.from(), this.to());
   }
 
-  @computed()
   public override profile(): CurveProfile {
     const segment = new LineSegment(this.from(), this.to());
 

--- a/packages/2d/src/components/Spline.ts
+++ b/packages/2d/src/components/Spline.ts
@@ -23,6 +23,7 @@ import {
   arc,
   bezierCurveTo,
   drawLine,
+  drawPivot,
   lineTo,
   moveTo,
   quadraticCurveTo,
@@ -293,13 +294,8 @@ export class Spline extends Curve {
     }
 
     context.lineWidth = 1;
-    const radius = 8;
     context.beginPath();
-    lineTo(context, offset.addY(-radius));
-    lineTo(context, offset.addY(radius));
-    lineTo(context, offset);
-    lineTo(context, offset.addX(-radius));
-    context.arc(offset.x, offset.y, radius, 0, Math.PI * 2);
+    drawPivot(context, offset);
     context.stroke();
 
     context.beginPath();

--- a/packages/2d/src/components/index.ts
+++ b/packages/2d/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './Latex';
 export * from './Layout';
 export * from './Line';
 export * from './Node';
+export * from './Ray';
 export * from './Rect';
 export * from './Polygon';
 export * from './QuadBezier';

--- a/packages/2d/src/utils/CanvasUtils.ts
+++ b/packages/2d/src/utils/CanvasUtils.ts
@@ -249,6 +249,18 @@ export function drawLine(
   }
 }
 
+export function drawPivot(
+  context: CanvasRenderingContext2D | Path2D,
+  offset: Vector2,
+  radius = 8,
+) {
+  lineTo(context, offset.addY(-radius));
+  lineTo(context, offset.addY(radius));
+  lineTo(context, offset);
+  lineTo(context, offset.addX(-radius));
+  arc(context, offset, radius);
+}
+
 export function arc(
   context: CanvasRenderingContext2D | Path2D,
   center: Vector2,


### PR DESCRIPTION
Adds a `Ray` node that represents an individual line segment:
```ts
import {makeScene2D} from '@motion-canvas/2d';
import {Ray} from '@motion-canvas/2d/lib/components';
import {createRef} from '@motion-canvas/core/lib/utils';

export default makeScene2D(function* (view) {
  const ray = createRef<Ray>();

  view.add(
    <Ray
      ref={ray}
      lineWidth={8}
      endArrow
      stroke={'lightseagreen'}
      fromX={-200}
      toX={200}
    />,
  );

  yield* ray().start(1, 1);
  yield* ray().start(0).end(0).start(1, 1);
});
```