### PR TITLE
feat(ui): add `?render` and `?present` url params

### DIFF
--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -35,6 +35,28 @@ export function editor(project: Project) {
   const presenter = new Presenter(project);
 
   const meta = project.meta;
+
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
+
+  const startInPresenter = urlParams.has('present');
+  const startInRenderer = urlParams.has('render');
+
+  if (startInPresenter) {
+    presenter.present({
+      ...meta.getFullRenderingSettings(),
+      name: project.name,
+      slide: null,
+    });
+  }
+
+  if (startInRenderer) {
+    renderer.render({
+      ...meta.getFullRenderingSettings(),
+      name: project.name,
+    });
+  }
+
   const playerKey = `${project.name}/player`;
   const frameKey = `${project.name}/frame`;
   const player = new Player(


### PR DESCRIPTION
**Summary**
This PR adds two URL parameters, `?render` and `?present`. These can be used for quick access to common UI functionality, leading to a somewhat automated process. (quick and dirty hack for #415? not headless, but automated)

**Functionality**
Simply append the URL in your browser with `?render` to automatically start rendering once the page loads, or `?present` to automatically load into presentation mode.

**Example usage**

![render](https://user-images.githubusercontent.com/80328580/235230503-233eaca7-f7d0-4d0e-ac7a-f43d0b870291.png) Rendering
![present](https://user-images.githubusercontent.com/80328580/235230577-ffc0f816-eb3c-4bc2-9440-29c763a623c3.png) Presenting



