### PR TITLE
fix: fix misnamed alt text in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br/>
 <p align="center">
   <a href="https://motion-canvas.github.io">
-    <img width="180" src="https://motion-canvas.github.io/img/logo_dark.svg" alt="Vite logo">
+    <img width="180" src="https://motion-canvas.github.io/img/logo_dark.svg" alt="Motion Canvas logo">
   </a>
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 <p align="center">
   <a href="https://lerna.js.org"><img src="https://img.shields.io/badge/published%20with-lerna-c084fc?style=flat" alt="published with lerna"></a>
-  <a href="https://vitejs.dev"><img src="https://img.shields.io/badge/powered%20by-vite-646cff?style=flat" alt="powered by lerna"></a>
+  <a href="https://vitejs.dev"><img src="https://img.shields.io/badge/powered%20by-vite-646cff?style=flat" alt="powered by vite"></a>
   <a href="https://www.npmjs.com/package/@motion-canvas/core"><img src="https://img.shields.io/npm/v/@motion-canvas/core?style=flat" alt="npm package version"></a>
   <a href="https://chat.motioncanvas.io"><img src="https://img.shields.io/discord/1071029581009657896?style=flat&logo=discord&logoColor=fff&color=404eed" alt="discord"></a>
 </p>


### PR DESCRIPTION
It is powered by Vite, published with Lerna. And the Motion Canvas logo is not the Vite logo. Probably just a copy-paste that no one saw because it's alt text.