### PR TITLE
feat(docs): improve Fiddle functionality

### DIFF
--- a/packages/docs/src/Icon/Image/index.tsx
+++ b/packages/docs/src/Icon/Image/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Image() {
+  return (
+    <svg width={24} height={24} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z" />
+    </svg>
+  );
+}

--- a/packages/docs/src/Icon/Split/index.tsx
+++ b/packages/docs/src/Icon/Split/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Split() {
+  return (
+    <svg width={24} height={24} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M3 15h8v-2H3v2zm0 4h8v-2H3v2zm0-8h8V9H3v2zm0-6v2h8V5H3zm10 0h8v14h-8V5z" />
+    </svg>
+  );
+}

--- a/packages/docs/src/Icon/Text/index.tsx
+++ b/packages/docs/src/Icon/Text/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Text() {
+  return (
+    <svg width={24} height={24} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M4 15h16v-2H4v2zm0 4h16v-2H4v2zm0-8h16V9H4v2zm0-6v2h16V5H4z" />
+    </svg>
+  );
+}

--- a/packages/docs/src/components/Fiddle/FiddleCodeBlock.tsx
+++ b/packages/docs/src/components/Fiddle/FiddleCodeBlock.tsx
@@ -8,7 +8,7 @@ export default function FiddleCodeBlock(props: Props) {
     isValidElement(props.children) &&
     (props.children.props as {editor: boolean} | null)?.editor
   ) {
-    return <Fiddle>{props.children.props.children}</Fiddle>;
+    return <Fiddle {...props.children.props.children} />;
   }
 
   return (

--- a/packages/docs/src/components/Fiddle/SharedPlayer.ts
+++ b/packages/docs/src/components/Fiddle/SharedPlayer.ts
@@ -29,6 +29,7 @@ let PlayerInstance: Player = null;
 let StageInstance: Stage = null;
 let CurrentSetter: (value: Player) => void = null;
 let CurrentParent: HTMLElement = null;
+let CurrentRatio = 1;
 
 export function disposePlayer(setter: (value: Player) => void) {
   if (CurrentSetter !== setter || !ProjectInstance) return;
@@ -41,6 +42,7 @@ export function disposePlayer(setter: (value: Player) => void) {
 export function borrowPlayer(
   setter: (value: Player) => void,
   parent: HTMLDivElement,
+  ratio: number,
 ): Player {
   if (setter === CurrentSetter) return;
 
@@ -66,7 +68,7 @@ export function borrowPlayer(
       scenes: [Description],
     } as Project;
     ProjectInstance.meta = new ProjectMetadata(ProjectInstance);
-    ProjectInstance.meta.shared.size.set([960, 960 / 4]);
+    ProjectInstance.meta.shared.size.set(960);
 
     PlayerInstance = new Player(ProjectInstance, {
       size: ProjectInstance.meta.shared.size.get(),
@@ -96,6 +98,17 @@ export function borrowPlayer(
   CurrentSetter?.(null);
   CurrentSetter = setter;
   CurrentParent = parent;
+  if (CurrentRatio !== ratio) {
+    ProjectInstance.meta.shared.size.set([960, Math.floor(960 / ratio)]);
+    Description.onReplaced.current = {
+      ...Description.onReplaced.current,
+      size: ProjectInstance.meta.shared.size.get(),
+    };
+    StageInstance.configure({
+      size: ProjectInstance.meta.shared.size.get(),
+    });
+    CurrentRatio = ratio;
+  }
 
   PlayerInstance.activate();
   PlayerInstance.requestReset();
@@ -105,6 +118,7 @@ export function borrowPlayer(
 export function tryBorrowPlayer(
   setter: (value: Player) => void,
   parent: HTMLDivElement,
+  ratio: number,
 ): Player | null {
-  return CurrentSetter ? null : borrowPlayer(setter, parent);
+  return CurrentSetter ? null : borrowPlayer(setter, parent, ratio);
 }

--- a/packages/docs/src/components/Fiddle/styles.module.css
+++ b/packages/docs/src/components/Fiddle/styles.module.css
@@ -1,8 +1,33 @@
 .root {
+  position: relative;
   border-radius: var(--ifm-code-border-radius);
   overflow: hidden;
   box-shadow: var(--ifm-global-shadow-lw);
   margin-bottom: var(--ifm-leading);
+}
+
+.root:hover .layoutControl {
+  opacity: 1;
+}
+
+.layoutControl {
+  transition: opacity 200ms ease-in-out;
+  opacity: 0;
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.layoutControl .icon {
+  transition: color var(--ifm-transition-fast);
+  color: var(--ifm-color-emphasis-300);
+}
+
+.icon.active {
+  color: var(--ifm-font-color-base);
+  pointer-events: none;
 }
 
 .progress {
@@ -18,6 +43,10 @@
   display: flex;
   border-bottom: 1px solid var(--ifm-color-emphasis-300);
   border-top: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.previewOnly .controls {
+  border-bottom: none;
 }
 
 .section {
@@ -56,7 +85,7 @@
   color: var(--ifm-font-color-base);
 }
 
-.controls button {
+.root button {
   appearance: none;
   background-color: unset;
   border: none;
@@ -78,12 +107,15 @@
   padding-left: 38px;
 }
 
+.source > div > div {
+  display: none !important;
+}
+
 .root .editor .source:first-child:last-child {
   display: block;
 }
 
 .preview {
-  aspect-ratio: 4;
   background-color: var(--ifm-background-surface-color);
   overflow: hidden;
   display: flex;
@@ -108,4 +140,20 @@
 
 .picker {
   margin-right: var(--ifm-button-padding-vertical);
+}
+
+.codeOnly .preview,
+.codeOnly .controls,
+.codeOnly .error,
+.codeOnly .progress,
+.codeOnly :global(.cm-editor) {
+  display: none !important;
+}
+.codeOnly .editor .source {
+  display: block;
+  padding-left: 0;
+}
+
+.previewOnly .editor {
+  display: none;
 }


### PR DESCRIPTION
Fiddles now support two additional properties:
- `ratio` - the aspect ratio of the preview
- `mode` - the default layout to use

Fiddles can be toggled between the three following modes:
- `code` - is rendered like a standard CodeBlock
- `editor` - an editor with a preview at the top
- `preview` - only the preview without the code

Users can switch between modes using a toolbar in the top right corner.

Example use:
````md
```tsx editor mode=preview ratio=16/9
// some code here
```
````

Closes: #637