### PR TITLE
feat(core): improve `SignalGenerator` chaining

### DIFF
--- a/packages/core/src/signals/types.ts
+++ b/packages/core/src/signals/types.ts
@@ -7,7 +7,40 @@ export type SignalGenerator<
   TSetterValue,
   TValue extends TSetterValue,
 > = ThreadGenerator & {
+  /**
+   * Tween to the specified value.
+   */
   to: SignalTween<TSetterValue, TValue>;
+  /**
+   * Tween back to the original value.
+   *
+   * @param time - The duration of the tween.
+   * @param timingFunction - The timing function of the tween.
+   * @param interpolationFunction - The interpolation function of the tween.
+   */
+  back: (
+    time: number,
+    timingFunction?: TimingFunction,
+    interpolationFunction?: InterpolationFunction<TValue>,
+  ) => SignalGenerator<TSetterValue, TValue>;
+  /**
+   * Wait for the specified duration.
+   *
+   * @param duration - The duration to wait.
+   */
+  wait: (duration: number) => SignalGenerator<TSetterValue, TValue>;
+  /**
+   * Run the given task.
+   *
+   * @param task - The generator to run.
+   */
+  run: (task: ThreadGenerator) => SignalGenerator<TSetterValue, TValue>;
+  /**
+   * Invoke the given callback.
+   *
+   * @param callback - The callback to invoke.
+   */
+  do: (callback: () => void) => SignalGenerator<TSetterValue, TValue>;
 };
 
 export interface SignalSetter<TValue, TOwner = void> {


### PR DESCRIPTION
`SignalGenerator` now has four additional methods for complex chaining:
```ts
yield* circle()
  // initiate the generator
  .scale(0.5, 2)
  // tween to another value
  .to(2, 2)
  // execute a callback
  .do(() => circle().fill('red'))
  // wait for one second
  .wait(1)
  // run the given generator
  .run(circle().position.y(100, 2))
  // tween back to the initial value
  .back(2);
```

Closes #480