### PR TITLE
feat(create): support command-line arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15672,8 +15672,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "license": "MIT"
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -22685,6 +22689,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
+        "minimist": "^1.2.8",
         "prompts": "^2.4.2"
       },
       "bin": {
@@ -26457,6 +26462,7 @@
         "@motion-canvas/core": "^3.7.0",
         "@motion-canvas/ui": "^3.7.0",
         "@motion-canvas/vite-plugin": "^3.7.0",
+        "minimist": "^1.2.8",
         "prompts": "^2.4.2"
       }
     },
@@ -33481,7 +33487,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6"
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 //@ts-check
 import prompts from 'prompts';
+import minimist from 'minimist';
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'node:url';
@@ -19,6 +20,7 @@ const MANIFEST = JSON.parse(
 );
 
 (async () => {
+  prompts.override(minimist(process.argv.slice(2)));
   const response = await prompts([
     {
       type: 'text',

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -26,6 +26,7 @@
     "@motion-canvas/vite-plugin": "^3.7.0"
   },
   "dependencies": {
+    "minimist": "^1.2.8",
     "prompts": "^2.4.2"
   }
 }


### PR DESCRIPTION
It's now possible to answer the prompts using command-line arguments:
```shell
npm init @motion-canvas@latest -- --name Hello --path ./hello --language ts
```