### PR TITLE
feat: add new hooks for plugins

### DIFF
--- a/packages/core/src/app/Project.ts
+++ b/packages/core/src/app/Project.ts
@@ -9,8 +9,18 @@ export interface ProjectSettings {
   plugins?: Plugin[];
   logger?: Logger;
   audio?: string;
+  /**
+   * @deprecated Configure the offset in the Video Settings tab of th editor.
+   */
   audioOffset?: number;
   variables?: Record<string, unknown>;
+}
+
+export interface Versions {
+  core: string;
+  two: string | null;
+  ui: string | null;
+  vitePlugin: string | null;
 }
 
 export interface Project {
@@ -20,20 +30,10 @@ export interface Project {
   logger: Logger;
   meta: ProjectMetadata;
   audio?: string;
-  audioOffset?: number;
   variables?: Record<string, unknown>;
-  versions: {
-    core: string;
-    two: string | null;
-    ui: string | null;
-    vitePlugin: string | null;
-  };
+  versions: Versions;
 }
 
 export function makeProject(settings: ProjectSettings) {
-  return {
-    logger: new Logger(),
-    plugins: [],
-    ...settings,
-  };
+  return settings;
 }

--- a/packages/core/src/app/bootstrap.ts
+++ b/packages/core/src/app/bootstrap.ts
@@ -1,0 +1,43 @@
+import {Logger} from './Logger';
+import {Project, ProjectSettings, Versions} from './Project';
+import {ProjectMetadata} from './ProjectMetadata';
+import {Plugin} from '../plugin';
+import {MetaFile} from '../meta';
+
+/**
+ * Bootstrap a project.
+ *
+ * @param name - The name of the project.
+ * @param versions - Package versions.
+ * @param plugins - Loaded plugins.
+ * @param settings - Project settings.
+ * @param metaFile - The meta file.
+ *
+ * @internal
+ */
+export function bootstrap(
+  name: string,
+  versions: Versions,
+  plugins: Plugin[],
+  settings: ProjectSettings,
+  metaFile: MetaFile<any>,
+): Project {
+  const reducedSettings = plugins.reduce(
+    (settings, plugin) => ({
+      ...settings,
+      ...(plugin.settings?.(settings) ?? {}),
+    }),
+    {name, ...settings} as ProjectSettings,
+  );
+
+  const project = {...reducedSettings} as Project;
+  project.versions = versions;
+  project.logger = new Logger();
+  project.plugins = plugins;
+  project.meta = new ProjectMetadata(project);
+  metaFile.attach(project.meta);
+
+  plugins.forEach(plugin => plugin.project?.(project));
+
+  return project;
+}

--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+export * from './bootstrap';
 export * from './Exporter';
 export * from './ImageExporter';
 export * from './Logger';

--- a/packages/core/src/plugin/DefaultPlugin.ts
+++ b/packages/core/src/plugin/DefaultPlugin.ts
@@ -1,12 +1,12 @@
 import {makePlugin} from './makePlugin';
-import {type ExporterClass, ImageExporter} from '../app';
+import {ImageExporter} from '../app';
 
 /**
  * The default plugin included in every Motion Canvas project.
  */
 export default makePlugin({
   name: 'mc-default-plugin',
-  exporters(): ExporterClass[] {
+  exporters() {
     return [ImageExporter];
   },
 });

--- a/packages/core/src/plugin/Plugin.ts
+++ b/packages/core/src/plugin/Plugin.ts
@@ -1,9 +1,36 @@
-import type {ExporterClass, Project} from '../app';
+import type {ExporterClass, Project, Player, ProjectSettings} from '../app';
 
 /**
  * Represents a runtime Motion Canvas plugin.
  */
 export interface Plugin {
   name: string;
+
+  /**
+   * Modify the project settings before the project is initialized.
+   *
+   * @param settings - The project settings.
+   */
+  settings?(settings: ProjectSettings): ProjectSettings | void;
+
+  /**
+   * Receive the project instance right after it is initialized.
+   *
+   * @param project - The project instance.
+   */
+  project?(project: Project): void;
+
+  /**
+   * Receive the player instance right after it is initialized.
+   *
+   * @param player - The player instance.
+   */
+  player?(player: Player): void;
+
+  /**
+   * Provide custom exporters for the project.
+   *
+   * @param project - The project instance.
+   */
   exporters?(project: Project): ExporterClass[];
 }

--- a/packages/core/src/plugin/makePlugin.ts
+++ b/packages/core/src/plugin/makePlugin.ts
@@ -12,6 +12,6 @@ import type {Plugin} from './Plugin';
  * });
  * ```
  */
-export function makePlugin(plugin: Plugin): Plugin {
-  return plugin;
+export function makePlugin(plugin: Plugin | (() => Plugin)): () => Plugin {
+  return typeof plugin === 'function' ? plugin : () => plugin;
 }

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -43,6 +43,7 @@ export function editor(project: Project) {
     getItem(playerKey, {}),
     getItem(frameKey, -1),
   );
+  project.plugins.forEach(plugin => plugin.player?.(player));
 
   player.onStateChanged.subscribe(state => {
     setItem(playerKey, state);

--- a/packages/vite-plugin/src/plugins.ts
+++ b/packages/vite-plugin/src/plugins.ts
@@ -60,6 +60,36 @@ export interface PluginOptions {
    * @param config - The configuration passed to the plugin.
    */
   config?(config: PluginConfig): Promise<void>;
+
+  /**
+   * Get custom configuration that will be passed to the runtime plugin.
+   *
+   * @remarks
+   * The config will be passed as the first argument to the default export of
+   * the runtime plugin. When provided as a string, it will be injected to the
+   * code as is, letting you define non-serializable values such as functions.
+   *
+   * If the returned value is an object, it will be converted to a JavaScript
+   * object using JSON serialization.
+   *
+   * @example
+   * Returning an object:
+   * ```ts
+   * {
+   *   runtimeConfig: () => ({
+   *     myText: 'Hello!',
+   *     myNumber: 42,
+   *   })
+   * }
+   * ```
+   * Returning a string:
+   * ```ts
+   * {
+   *   runtimeConfig: () => `{myRegex: /\\.wav$/}`
+   * }
+   * ```
+   */
+  runtimeConfig?(): Promise<any>;
 }
 
 /**


### PR DESCRIPTION
Plugins can implement the following new hooks:
- `settings` - Modifies the project settings before initialization.
- `project` - Receives the project instance.
- `player` - Receives the player instance.