### PR TITLE
fix(docs) nonexistent reference in media documentation

### DIFF
--- a/packages/docs/docs/getting-started/media.mdx
+++ b/packages/docs/docs/getting-started/media.mdx
@@ -137,7 +137,7 @@ import {Video} from '@motion-canvas/2d/lib/components';
 import exampleMp4 from '../../videos/example.mp4';
 
 export default makeScene2D(function* (view) {
-  view.add(<Video ref={videoRef} src={exampleMp4} />);
+  view.add(<Video src={exampleMp4} />);
 });
 ```
 


### PR DESCRIPTION
In the Video example without a reference in section about media in the documentation there is a `ref` in the JSX element, but the variable it binds to does not exist. This pull-request fixes that.