### PR TITLE
feat(core): add `gauss` function to `Random`

### DIFF
--- a/packages/core/src/scenes/Random.ts
+++ b/packages/core/src/scenes/Random.ts
@@ -40,6 +40,28 @@ export class Random {
     return value;
   }
 
+  // This is an optimization.
+  // Since gauss() generates a pair of independent Gaussian random numbers,
+  // it returns one immediately and stores the other for the next call to gauss().
+  private nextGauss: number | null = null;
+
+  /**
+   * Get a random float from a gaussian distribution.
+   * @param mean - The mean of the distribution.
+   * @param stdev - The standard deviation of the distribution.
+   */
+  public gauss(mean = 0.0, stdev = 1.0): number {
+    let z = this.nextGauss;
+    this.nextGauss = null;
+    if (z === null) {
+      const x2pi = this.next() * 2 * Math.PI;
+      const g2rad = Math.sqrt(-2.0 * Math.log(1.0 - this.next()));
+      z = Math.cos(x2pi) * g2rad;
+      this.nextGauss = Math.sin(x2pi) * g2rad;
+    }
+    return mean + z * stdev;
+  }
+
   /**
    * Get an array filled with random floats in the given range.
    *

--- a/packages/core/src/scenes/Random.ts
+++ b/packages/core/src/scenes/Random.ts
@@ -6,6 +6,17 @@ import {range} from '../utils';
  * {@link https://gist.github.com/tommyettinger/46a874533244883189143505d203312c | Mulberry32}.
  */
 export class Random {
+  /**
+   * Previously generated Gaussian random number.
+   *
+   * @remarks
+   * This is an optimization.
+   * Since {@link gauss} generates a pair of independent Gaussian random
+   * numbers, it returns one immediately and stores the other for the next call
+   * to {@link gauss}.
+   */
+  private nextGauss: number | null = null;
+
   public constructor(private state: number) {}
 
   /**
@@ -40,22 +51,17 @@ export class Random {
     return value;
   }
 
-  // This is an optimization.
-  // Since gauss() generates a pair of independent Gaussian random numbers,
-  // it returns one immediately and stores the other for the next call to gauss().
-  private nextGauss: number | null = null;
-
   /**
    * Get a random float from a gaussian distribution.
    * @param mean - The mean of the distribution.
    * @param stdev - The standard deviation of the distribution.
    */
-  public gauss(mean = 0.0, stdev = 1.0): number {
+  public gauss(mean = 0, stdev = 1): number {
     let z = this.nextGauss;
     this.nextGauss = null;
     if (z === null) {
       const x2pi = this.next() * 2 * Math.PI;
-      const g2rad = Math.sqrt(-2.0 * Math.log(1.0 - this.next()));
+      const g2rad = Math.sqrt(-2 * Math.log(1 - this.next()));
       z = Math.cos(x2pi) * g2rad;
       this.nextGauss = Math.sin(x2pi) * g2rad;
     }


### PR DESCRIPTION
`gauss(mean, stdev)` will return a normally distributed random value with a given `mean` and `stdev`.

The implementation was ported to TypeScript from Python's `random.gauss()`: https://docs.python.org/3/library/random.html#random.gauss

It includes a small optimization that caches a second independent random value
since the function always generates a pair.