### PR TITLE
Fix typos in docs code

### DIFF
--- a/packages/docs/docs/getting-started/flow.mdx
+++ b/packages/docs/docs/getting-started/flow.mdx
@@ -193,7 +193,7 @@ This is similar to above, but uses a `for` loop and an array of generators.
 
 ```tsx
 const generators = [];
-for (const ref of rects) {
+for (const rect of rects) {
   // No yield here, just store the generators.
   generators.push(rect.position.y(100, 1).to(-100, 2).to(0, 1));
 }
@@ -209,7 +209,7 @@ would take for the generator in the loop to complete, but is useful in some
 situations.
 
 ```tsx
-for (const ref of rects) {
+for (const rect of rects) {
   // Note the absence of a * after this yield
   yield rect.position.y(100, 1).to(-100, 2).to(0, 1);
 }

--- a/packages/docs/docs/getting-started/references.mdx
+++ b/packages/docs/docs/getting-started/references.mdx
@@ -197,7 +197,7 @@ function Label({
   );
 }
 
-const label = {rect: null as Rect, text: null as Text};
+const label = {rect: null as Rect, text: null as Txt};
 view.add(<Label refs={label}>HELLO</Label>);
 
 // we can now animate both the Rect and the Text of our label:
@@ -233,7 +233,7 @@ function Label({
 }
 
 // highlight-next-line
-const label = {rect: null as Rect, text: null as Text};
+const label = {rect: null as Rect, text: null as Txt};
 view.add(<Label refs={label}>HELLO</Label>);
 ```
 


### PR DESCRIPTION
Some simple fixes, I found while following the tutorial...