### PR TITLE
fix(ui): add min-width and z-index on hover to range handle

### DIFF
--- a/packages/ui/src/components/timeline/Timeline.module.scss
+++ b/packages/ui/src/components/timeline/Timeline.module.scss
@@ -302,6 +302,8 @@
 
   .range:hover > & {
     color: rgba(255, 255, 255, 0.24);
+    z-index: 1;
+    min-width: 24px;
   }
 
   .range > &:hover,


### PR DESCRIPTION
Fixes #738 

Now the range handles are visible whenever range is hovered. 
So even when zooming out a lot it's still possible to change the range.

Let me know if you think a better solution could be done.

https://github.com/motion-canvas/motion-canvas/assets/38408878/24aaff8d-9511-48d3-8857-d1342317fa89
