### PR TITLE
Docs: Fix makeRef import for Looping example code snippet

### DIFF
--- a/packages/docs/docs/getting-started/flow.mdx
+++ b/packages/docs/docs/getting-started/flow.mdx
@@ -141,7 +141,7 @@ using them in the below editor.
 
 ```tsx editor ratio=2
 import {makeScene2D, Rect} from '@motion-canvas/2d';
-import {all, waitFor, makeRef, range} from '@motion-canvas/core/lib/flow';
+import {all, waitFor, makeRef, range} from '@motion-canvas/core';
 
 export default makeScene2D(function* (view) {
   const rects: Rect[] = [];


### PR DESCRIPTION
importing makeRef from '@motion-canvas/core/lib/flow' does not work the javascript project. It has to be imported from @motion-canvas/core