### PR TITLE
docs: update quickstart

### DIFF
--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -346,6 +346,17 @@ You can press `0` to refocus the camera on the preview.
 </details>
 <details>
   <summary>
+    The animation ends abruptly or does not start at the beginning.
+  </summary>
+
+Make sure the playback range selector in the timeline starts and ends where you
+expect it to, e.g., at the beginning and end of your animation. The range
+selector is a gray bar in the time axis of your timeline. When you move your
+mouse over it, six dots will appear allowing you to manipulate it.
+
+</details>
+<details>
+  <summary>
     File watching does not work on Windows Subsystem for Linux (WSL) 2
   </summary>
 


### PR DESCRIPTION
Added hint that the playback range selector may be the cause of prematurely ending animations