### PR TITLE
feat(docs): add Documentation for LaTeX Node to Latex JSDoc

### DIFF
--- a/packages/2d/src/components/Latex.ts
+++ b/packages/2d/src/components/Latex.ts
@@ -34,27 +34,16 @@ export interface LatexProps extends ImgProps {
  *
  * @preview
  * ```tsx editor
- * import {Latex} from '@motion-canvas/2d/lib/components';
- * import {makeScene2D} from '@motion-canvas/2d/lib/scenes';
- * import {waitFor} from '@motion-canvas/core/lib/flow';
- * import {createRef} from '@motion-canvas/core/lib/utils';
+ * import {Latex, makeScene2D} from '@motion-canvas/2d';
  *
  * export default makeScene2D(function* (view) {
- *   const tex = createRef<Latex>();
  *   view.add(
  *     <Latex
- *       ref={tex}
  *       // Note how this uses \color to set the color.
  *       tex="{\color{white} ax^2+bx+c=0 \implies x=\frac{-b \pm \sqrt{b^2-4ac}}{2a}}"
- *       y={0}
  *       width={600} // height and width can calculate based on each other
  *     />,
  *   );
- *
- *   yield* waitFor(2);
- *   yield* tex().opacity(0, 1);
- *   yield* waitFor(2);
- *   yield* tex().opacity(1, 1);
  * });
  * ```
  */

--- a/packages/2d/src/components/Latex.ts
+++ b/packages/2d/src/components/Latex.ts
@@ -29,6 +29,35 @@ export interface LatexProps extends ImgProps {
   renderProps?: SignalValue<OptionList>;
 }
 
+/**
+ * A node for rendering equations with LaTeX.
+ *
+ * @preview
+ * ```tsx editor
+ * import {Latex} from '@motion-canvas/2d/lib/components';
+ * import {makeScene2D} from '@motion-canvas/2d/lib/scenes';
+ * import {waitFor} from '@motion-canvas/core/lib/flow';
+ * import {createRef} from '@motion-canvas/core/lib/utils';
+ *
+ * export default makeScene2D(function* (view) {
+ *   const tex = createRef<Latex>();
+ *   view.add(
+ *     <Latex
+ *       ref={tex}
+ *       // Note how this uses \color to set the color.
+ *       tex="{\color{white} ax^2+bx+c=0 \implies x=\frac{-b \pm \sqrt{b^2-4ac}}{2a}}"
+ *       y={0}
+ *       width={600} // height and width can calculate based on each other
+ *     />,
+ *   );
+ *
+ *   yield* waitFor(2);
+ *   yield* tex().opacity(0, 1);
+ *   yield* waitFor(2);
+ *   yield* tex().opacity(1, 1);
+ * });
+ * ```
+ */
 export class Latex extends Img {
   private static svgContentsPool: Record<string, string> = {};
 


### PR DESCRIPTION
Resolve #755 
This adds a simple Latex example to the JSDoc of the Latex component. 

![image](https://github.com/motion-canvas/motion-canvas/assets/27686785/3fa1a62e-d8ad-489e-a3f5-71014f576ca2)

