### PR TITLE
feat(2d): add start and end signals to Grid node

### DIFF
--- a/packages/2d/src/components/Grid.ts
+++ b/packages/2d/src/components/Grid.ts
@@ -40,14 +40,14 @@ export interface GridProps extends ShapeProps {
  *       width={'100%'}
  *       height={'100%'}
  *       stroke={'#666'}
- *       start={0.5}
- *       end={0.5}
+ *       start={0}
+ *       end={1}
  *     />,
  *   );
  *
  *   yield* all(
- *     grid().end(1, 1).wait(1).to(0.5, 1),
- *     grid().start(0, 1).wait(1).to(0.5, 1),
+ *     grid().end(0.5, 1).to(1, 1).wait(1),
+ *     grid().start(0.5, 1).to(0, 1).wait(1),
  *   );
  * });
  * ```
@@ -67,7 +67,7 @@ export class Grid extends Shape {
    * The portion of each grid line that comes before the given percentage will
    * be made invisible.
    *
-   * This property is usefully for animating the grid appearing on screen.
+   * This property is useful for animating the grid appearing on-screen.
    */
   @initial(0)
   @signal()
@@ -80,7 +80,7 @@ export class Grid extends Shape {
    * The portion of each grid line that comes after the given percentage will
    * be made invisible.
    *
-   * This property is usefully for animating the grid appearing on screen.
+   * This property is useful for animating the grid appearing on-screen.
    */
   @initial(1)
   @signal()

--- a/packages/2d/src/components/Grid.ts
+++ b/packages/2d/src/components/Grid.ts
@@ -1,16 +1,90 @@
 import {Shape, ShapeProps} from './Shape';
-import {PossibleVector2, Vector2Signal} from '@motion-canvas/core/lib/types';
-import {initial, vector2Signal} from '../decorators';
-import {SignalValue} from '@motion-canvas/core/lib/signals';
+import {initial, signal, vector2Signal} from '../decorators';
+import {
+  SimpleSignal,
+  SignalValue,
+  PossibleVector2,
+  Vector2Signal,
+  map,
+} from '@motion-canvas/core';
 
 export interface GridProps extends ShapeProps {
+  /**
+   * {@inheritDoc Grid.spacing}
+   */
   spacing?: SignalValue<PossibleVector2>;
+  /**
+   * {@inheritDoc Grid.start}
+   */
+  start?: SignalValue<number>;
+  /**
+   * {@inheritDoc Grid.end}
+   */
+  end?: SignalValue<number>;
 }
 
+/**
+ * A node for drawing a two-dimensional grid.
+ *
+ * @preview
+ * ```tsx editor
+ * import {Grid, makeScene2D} from '@motion-canvas/2d';
+ * import {all, createRef} from '@motion-canvas/core';
+ *
+ * export default makeScene2D(function* (view) {
+ *   const grid = createRef<Grid>();
+ *
+ *   view.add(
+ *     <Grid
+ *       ref={grid}
+ *       width={'100%'}
+ *       height={'100%'}
+ *       stroke={'#666'}
+ *       start={0.5}
+ *       end={0.5}
+ *     />,
+ *   );
+ *
+ *   yield* all(
+ *     grid().end(1, 1).wait(1).to(0.5, 1),
+ *     grid().start(0, 1).wait(1).to(0.5, 1),
+ *   );
+ * });
+ * ```
+ */
 export class Grid extends Shape {
+  /**
+   * The spacing between the grid lines.
+   */
   @initial(80)
   @vector2Signal('spacing')
   public declare readonly spacing: Vector2Signal<this>;
+
+  /**
+   * The percentage that should be clipped from the beginning of each grid line.
+   *
+   * @remarks
+   * The portion of each grid line that comes before the given percentage will
+   * be made invisible.
+   *
+   * This property is usefully for animating the grid appearing on screen.
+   */
+  @initial(0)
+  @signal()
+  public declare readonly start: SimpleSignal<number, this>;
+
+  /**
+   * The percentage that should be clipped from the end of each grid line.
+   *
+   * @remarks
+   * The portion of each grid line that comes after the given percentage will
+   * be made invisible.
+   *
+   * This property is usefully for animating the grid appearing on screen.
+   */
+  @initial(1)
+  @signal()
+  public declare readonly end: SimpleSignal<number, this>;
 
   public constructor(props: GridProps) {
     super(props);
@@ -26,19 +100,34 @@ export class Grid extends Shape {
     const steps = size.div(spacing).floored;
 
     for (let x = -steps.x; x <= steps.x; x++) {
+      const [from, to] = this.mapPoints(-size.height, size.height);
+
       context.beginPath();
-      context.moveTo(spacing.x * x, -size.height);
-      context.lineTo(spacing.x * x, size.height);
+      context.moveTo(spacing.x * x, from);
+      context.lineTo(spacing.x * x, to);
       context.stroke();
     }
 
     for (let y = -steps.y; y <= steps.y; y++) {
+      const [from, to] = this.mapPoints(-size.width, size.width);
+
       context.beginPath();
-      context.moveTo(-size.width, spacing.y * y);
-      context.lineTo(size.width, spacing.y * y);
+      context.moveTo(from, spacing.y * y);
+      context.lineTo(to, spacing.y * y);
       context.stroke();
     }
 
     context.restore();
+  }
+
+  private mapPoints(start: number, end: number): [number, number] {
+    let from = map(start, end, this.start());
+    let to = map(start, end, this.end());
+
+    if (to < from) {
+      [from, to] = [to, from];
+    }
+
+    return [from, to];
   }
 }


### PR DESCRIPTION
This PR adds `start` and `end` signals to the `Grid` node. These signals can be used to animate the grid appearing on screen similar to lines or curves work.

## Example

```tsx
export default makeScene2D(function* (view) {
  const grid = createRef<Grid>();

  view.add(
    <Grid
      ref={grid}
      width={'100%'}
      height={'100%'}
      stroke={'#666'}
      start={0.5}
      end={0.5}
    />,
  );

  yield* all(
    grid().end(1, 1).wait(1).to(0.5, 1),
    grid().start(0, 1).wait(1).to(0.5, 1),
  );
});
```

https://github.com/motion-canvas/motion-canvas/assets/5139098/38f15add-dbb1-4c91-9a7c-8e0283251b8f
