### PR TITLE
feat(2d): add SVG component

### DIFF
--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -438,8 +438,11 @@ export class SVG extends Shape {
     } else if (child.tagName === 'use') {
       const hrefElement = svgRoot.querySelector(
         (child as SVGUseElement).href.baseVal,
-      )!;
-      if (!(hrefElement instanceof SVGGraphicsElement)) return;
+      );
+      if (!(hrefElement instanceof SVGGraphicsElement)) {
+        useLogger().warn(`invalid SVG use tag. element "${child.outerHTML}"`);
+        return;
+      }
 
       yield* SVG.extractElementNodes(
         hrefElement,

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -630,7 +630,6 @@ export class SVG extends Shape {
    * @param name - The name of the attribute to parse.
    * @returns a parsed number or `0` if the attribute is not defined.
    */
-
   private static parseNumberAttribute(
     element: SVGElement,
     name: string,

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -483,7 +483,7 @@ export class SVG extends Shape {
       }),
     );
     this.wrapper.children(currentSVG.nodes.map(shape => shape.shape));
-    for (const item of applyResult.inserted) {
+    for (const {item} of applyResult.inserted) {
       item.current.shape.parent(this.wrapper);
     }
 

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -92,6 +92,12 @@ export class SVG extends Shape {
     return this.document().nodes.map(node => node.shape);
   }
 
+  public getChildrenById(id: string) {
+    return this.document()
+      .nodes.filter(node => node.id === id)
+      .map(({shape}) => shape);
+  }
+
   protected buildDocument(data: SVGDocumentData): SVGDocument {
     return {
       size: data.size,

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -78,8 +78,10 @@ export interface SVGProps extends ShapeProps {
 }
 
 /**
- * Node to render and animating SVG.
- * You should use Image node if you do not want to animate children.
+A Node for drawing and animating SVG images.
+
+@remarks
+If you're not interested in animating SVG, you can use {@link Img} instead.
  */
 export class SVG extends Shape {
   @lazy(() => {
@@ -113,9 +115,8 @@ export class SVG extends Shape {
   }
 
   /**
-   * Get SVG node by id.
-   * @param id - id
-   * @returns list of Node that have matched id
+   * Get all SVG nodes with the given id.
+   * @param id - An id to query.
    */
   public getChildrenById(id: string) {
     return this.document()
@@ -158,9 +159,8 @@ export class SVG extends Shape {
   }
 
   /**
-   * Convert SVGDocumentData into SVGDocument
-   * @param data - SVGDocumentData
-   * @returns SVGDocument
+   * Convert `SVGDocumentData` to `SVGDocument`.
+   * @param data - `SVGDocumentData` to convert.
    */
   protected buildDocument(data: SVGDocumentData): SVGDocument {
     return {
@@ -170,9 +170,8 @@ export class SVG extends Shape {
   }
 
   /**
-   * Build SVGShapeData into SVGShape
-   * @param data - SVGShapeData
-   * @returns SVGShape
+   * Convert `SVGShapeData` to `SVGShape`.
+   * @param data - `SVGShapeData` to convert.
    */
   protected buildShape({id, type, props, children}: SVGShapeData): SVGShape {
     return {
@@ -185,25 +184,24 @@ export class SVG extends Shape {
   }
 
   /**
-   * Parse SVG as SVGDocument
-   * @param svg - svg string to be parsed
-   * @returns - SVGDocument
+   * Convert an SVG string to `SVGDocument`.
+   * @param svg - An SVG string to be parsed.
    */
   protected parseSVG(svg: string): SVGDocument {
     return this.buildDocument(SVG.parseSVGData(svg));
   }
 
   /**
-   * Create tweening list to tween node from initial node to final node.
-   * @param from - Initial node
-   * @param to - Final node
-   * @param time - time for tweening
-   * @param timing - timing for tweening
+   * Create a tweening list to tween between two SVG nodes.
+   * @param from - The initial node,
+   * @param to - The final node.
+   * @param duration - The duration of the tween.
+   * @param timing - The timing function.
    */
   protected *generateTransformer(
     from: Node,
     to: Node,
-    time: number,
+    duration : number,
     timing: TimingFunction,
   ): Generator<ThreadGenerator> {
     yield from.position(to.position(), time, timing);
@@ -352,8 +350,7 @@ export class SVG extends Shape {
   }
 
   /**
-   * Get current SVGDocument
-   * @returns
+   * Get the current `SVGDocument`.
    */
   @computed()
   private document(): SVGDocument {
@@ -370,7 +367,7 @@ export class SVG extends Shape {
   }
 
   /**
-   * Get current document nodes
+   * Get current document nodes.
    */
   @computed()
   private documentNodes() {
@@ -378,9 +375,9 @@ export class SVG extends Shape {
   }
 
   /**
-   * Convert SVG color in Shape properties into MotionCanvas color.
-   * @param param - Shape properties
-   * @returns Converted Shape properties
+   * Convert SVG colors in Shape properties to Motion Canvas colors.
+   * @param param - Shape properties.
+   * @returns Converted Shape properties.
    */
   private processElementStyle({fill, stroke, ...rest}: ShapeProps): ShapeProps {
     return {
@@ -392,11 +389,10 @@ export class SVG extends Shape {
   }
 
   /**
-   * Parse SVG as SVGDocumentData
-   * @param svg - svg string to be parsed
-   * @returns SVGDocumentData that can be used to build SVGDocument
+   * Parse an SVG string as `SVGDocumentData`.
+   * @param svg - And SVG string to be parsed.
+   * @returns `SVGDocumentData` that can be used to build SVGDocument.
    */
-
   protected static parseSVGData(svg: string) {
     const cached = SVG.svgNodesPool[svg];
     if (cached && (cached.size.x > 0 || cached.size.y > 0)) return cached;
@@ -477,9 +473,9 @@ export class SVG extends Shape {
   }
 
   /**
-   * Convert SVG color into MotionCanvas color
-   * @param color - SVG color
-   * @returns MotionCanvas color
+   * Convert an SVG color into a Motion Canvas color.
+   * @param color - SVG color.
+   * @returns Motion Canvas color.
    */
   private static processSVGColor(
     color: SignalValue<PossibleCanvasStyle> | undefined,
@@ -497,10 +493,9 @@ export class SVG extends Shape {
   }
 
   /**
-   * Get final SVG element transformation.
-   * @param element - SVG element
-   * @param parentTransform - Tranformation that applied into children
-   * @returns - Current SVG element final transformation
+   * Get the final transformation matrix for the given SVG element.
+   * @param element - SVG element.
+   * @param parentTransform - The transformation matrix of the parent.
    */
   private static getElementTransformation(
     element: SVGGraphicsElement,
@@ -563,10 +558,9 @@ export class SVG extends Shape {
   }
 
   /**
-   * Convert SVG style into MotionCanvas Shape
-   * @param element - SVG element
-   * @param inheritedStyle - Parent style that must inherited to this element
-   * @returns - MotionCanvas Shape properties
+   * Convert the SVG element's style to a Motion Canvas Shape properties.
+   * @param element - An SVG element whose style should be converted.
+   * @param inheritedStyle - The parent style that should be inherited.
    */
   private static getElementStyle(
     element: SVGGraphicsElement,
@@ -598,14 +592,13 @@ export class SVG extends Shape {
   }
 
   /**
-   * Extract SVGShapeData list from SVG element children.
-   * This will not extract current element shape.
-   * @param element - Element to be extracted
-   * @param svgRoot - SVG root ("svg" tag) of element
-   * @param parentTransform - Matrix transformation applied to parent
-   * @param inheritedStyle - style of current SVG `element` that must inherited to its children
+   * Extract `SVGShapeData` list from the SVG element's children.
+   * This will not extract the current element's shape.
+   * @param element - An element whose children will be extracted.
+   * @param svgRoot - The SVG root ("svg" tag) of the element.
+   * @param parentTransform - The transformation matrix applied to the parent.
+   * @param inheritedStyle - The style of the current SVG `element` that the children should inherit.
    */
-
   private static *extractGroupNodes(
     element: SVGElement,
     svgRoot: Element,
@@ -625,10 +618,10 @@ export class SVG extends Shape {
   }
 
   /**
-   * Parse number from SVG element attribute
-   * @param element - SVG element whoose element will be parsed
-   * @param name - attribute name to be parse
-   * @returns  parsed number or 0 if attribute is not defined
+   * Parse a number from an SVG element attribute.
+   * @param element - SVG element whose attribute will be parsed.
+   * @param name - The name of the attribute to parse.
+   * @returns a parsed number or `0` if the attribute is not defined.
    */
 
   private static parseNumberAttribute(
@@ -639,13 +632,13 @@ export class SVG extends Shape {
   }
 
   /**
-   * Extract SVGShapeData list from SVG element. This also will extract shape from children.
-   * @param child - SVG element to extract
-   * @param svgRoot - SVG root ("svg" tag) of element
-   * @param parentTransform - Matrix transformation applied to parent
-   * @param inheritedStyle - parent style that must inherited into current shape style
+   * Extract `SVGShapeData` list from the SVG element.
+   * This will also recursively extract shapes from its children.
+   * @param child - An SVG element to extract.
+   * @param svgRoot - The SVG root ("svg" tag) of the element.
+   * @param parentTransform - The transformation matrix applied to the parent.
+   * @param inheritedStyle - The style of the parent SVG element that the element should inherit.
    */
-
   private static *extractElementNodes(
     child: SVGGraphicsElement,
     svgRoot: Element,

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -529,9 +529,13 @@ export class SVG extends Shape {
         if (autoWidth) this.width.reset();
         if (autoHeight) this.height.reset();
 
+        for (const {current} of diff.inserted) {
+          current.shape.dispose();
+        }
         for (const {current} of diff.deleted) current.shape.dispose();
-        for (const {from} of diff.transformed) {
+        for (const {from, to} of diff.transformed) {
           from.current.shape.dispose();
+          to.current.shape.dispose();
         }
       },
     );

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -1,0 +1,690 @@
+import {SignalValue, SimpleSignal} from '@motion-canvas/core/lib/signals';
+import {
+  BBox,
+  PossibleSpacing,
+  SerializedVector2,
+  Vector2,
+} from '@motion-canvas/core/lib/types';
+import {computed, signal} from '../decorators';
+import {Shape, ShapeProps} from './Shape';
+import {Node, NodeProps} from './Node';
+import {DesiredLength, PossibleCanvasStyle} from '../partials';
+import {useLogger} from '@motion-canvas/core/lib/utils';
+import {Path, PathProps} from './Path';
+import {Rect, RectProps} from './Rect';
+import {
+  clampRemap,
+  easeInOutSine,
+  TimingFunction,
+  tween,
+} from '@motion-canvas/core/lib/tweening';
+import {Layout} from './Layout';
+import {lazy, threadable} from '@motion-canvas/core/lib/decorators';
+import {View2D} from './View2D';
+import {all, delay} from '@motion-canvas/core/lib/flow';
+import {ThreadGenerator} from '@motion-canvas/core/lib/threading';
+import {Circle, CircleProps} from './Circle';
+import {Line, LineProps} from './Line';
+import {Img, ImgProps} from './Img';
+
+export interface SVGShape {
+  id: string;
+  shape: Node;
+}
+
+export interface SVGShapeData {
+  id: string;
+  type: new (props: NodeProps) => Node;
+  props: ShapeProps;
+  children?: SVGShapeData[];
+}
+
+export interface SVGDocument {
+  size: Vector2;
+  nodes: SVGShape[];
+}
+
+export interface SVGDocumentData {
+  size: Vector2;
+  nodes: SVGShapeData[];
+}
+
+interface SVGDiffShape {
+  index: number;
+  node: SVGShape;
+}
+
+interface SVGDiff {
+  fromSize: Vector2;
+  toSize: Vector2;
+  inserted: Array<SVGDiffShape>;
+  deleted: Array<SVGDiffShape>;
+  transformed: Array<{
+    insert: boolean;
+    deleted: boolean;
+    from: SVGDiffShape;
+    to: SVGDiffShape;
+  }>;
+}
+
+export interface SVGProps extends ShapeProps {
+  svg?: SignalValue<string>;
+}
+
+export class SVG extends Shape {
+  @lazy(() => {
+    const element = document.createElement('div');
+    View2D.shadowRoot.appendChild(element);
+    return element;
+  })
+  protected static containerElement: HTMLDivElement;
+  private static svgNodesPool: Record<string, SVGDocumentData> = {};
+  @signal()
+  public declare readonly svg: SimpleSignal<string, this>;
+  public wrapper: Node;
+
+  public constructor(props: SVGProps) {
+    super(props);
+    this.wrapper = new Node({});
+    this.wrapper.children(this.documentNodes);
+    this.add(this.wrapper);
+  }
+
+  protected override desiredSize(): SerializedVector2<DesiredLength> {
+    const custom = super.desiredSize();
+    const {x, y} = this.document().size.mul(this.wrapper.scale());
+    return {
+      x: custom.x ?? x,
+      y: custom.y ?? y,
+    };
+  }
+
+  @computed()
+  private document() {
+    return this.parseSVG(this.svg());
+  }
+
+  @computed()
+  private documentNodes() {
+    return this.document().nodes.map(node => node.shape);
+  }
+
+  protected buildDocument(data: SVGDocumentData): SVGDocument {
+    return {
+      size: data.size,
+      nodes: data.nodes.map(ch => this.buildShape(ch)),
+    };
+  }
+
+  protected buildShape({id, type, props, children}: SVGShapeData): SVGShape {
+    return {
+      id,
+      shape: new type({
+        children: children?.map(ch => this.buildShape(ch).shape),
+        ...this.processElementStyle(props),
+      }),
+    };
+  }
+
+  private static processSVGColor(
+    color: SignalValue<PossibleCanvasStyle> | undefined,
+  ): SignalValue<PossibleCanvasStyle> | undefined {
+    if (color === 'transparent' || color === 'none') {
+      return {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+      };
+    }
+
+    return color;
+  }
+
+  private processElementStyle({fill, stroke, ...rest}: ShapeProps): ShapeProps {
+    return {
+      fill: fill === 'currentColor' ? this.fill : SVG.processSVGColor(fill),
+      stroke:
+        stroke === 'currentColor' ? this.stroke : SVG.processSVGColor(stroke),
+      ...rest,
+    };
+  }
+
+  protected parseSVG(svg: string): SVGDocument {
+    return this.buildDocument(SVG.parseSVGData(svg));
+  }
+
+  protected static parseSVGData(svg: string) {
+    const cached = SVG.svgNodesPool[svg];
+    if (cached && (cached.size.x > 0 || cached.size.y > 0)) return cached;
+
+    SVG.containerElement.innerHTML = svg;
+
+    const svgRoot = SVG.containerElement.querySelector('svg')!;
+    let viewBox: BBox = new BBox();
+    let size: Vector2 = new Vector2();
+
+    const hasViewBox = svgRoot.hasAttribute('viewBox');
+    const hasSize =
+      svgRoot.hasAttribute('width') || svgRoot.hasAttribute('height');
+
+    if (hasViewBox) {
+      const {x, y, width, height} = svgRoot.viewBox.baseVal;
+      viewBox = new BBox(x, y, width, height);
+
+      if (!hasSize) size = viewBox.size;
+    }
+
+    if (hasSize) {
+      size = new Vector2(
+        svgRoot.width.baseVal.value,
+        svgRoot.height.baseVal.value,
+      );
+
+      if (!hasViewBox) viewBox = new BBox(0, 0, size.width, size.height);
+    }
+
+    if (!hasViewBox && !hasSize) {
+      viewBox = new BBox(svgRoot.getBBox());
+      size = viewBox.size;
+    }
+
+    const scale = size.div(viewBox.size);
+    const center = viewBox.center;
+
+    const rootTransform = new DOMMatrix()
+      .scaleSelf(scale.x, scale.y)
+      .translateSelf(-center.x, -center.y);
+
+    const nodes = Array.from(
+      SVG.extractGroupNodes(svgRoot, svgRoot, rootTransform, {}),
+    );
+    const builder: SVGDocumentData = {
+      size,
+      nodes,
+    };
+    SVG.svgNodesPool[svg] = builder;
+    return builder;
+  }
+
+  private static getElementTransformation(
+    element: SVGGraphicsElement,
+    parentTransform: DOMMatrix,
+  ) {
+    const transform = element.transform.baseVal.consolidate();
+    const transformMatrix = (
+      transform ? parentTransform.multiply(transform.matrix) : parentTransform
+    ).translate(
+      SVG.parseNumberAttribute(element, 'x'),
+      SVG.parseNumberAttribute(element, 'y'),
+    );
+    return transformMatrix;
+  }
+
+  private static getElementStyle(
+    element: SVGGraphicsElement,
+    inheritedStyle: ShapeProps,
+  ): ShapeProps {
+    return {
+      fill: element.getAttribute('fill') ?? inheritedStyle.fill,
+      stroke: element.getAttribute('stroke') ?? inheritedStyle.stroke,
+      lineWidth: element.hasAttribute('stroke-width')
+        ? parseFloat(element.getAttribute('stroke-width')!)
+        : inheritedStyle.lineWidth,
+      layout: false,
+    };
+  }
+
+  protected static getMatrixTransformation(transform: DOMMatrix): ShapeProps {
+    const position = {
+      x: transform.m41,
+      y: transform.m42,
+    };
+    const rotation = (Math.atan2(transform.m12, transform.m11) * 180) / Math.PI;
+    const scale = {
+      x: Vector2.magnitude(transform.m11, transform.m12),
+      y: Vector2.magnitude(transform.m21, transform.m22),
+    };
+    const determinant =
+      transform.m11 * transform.m22 - transform.m12 * transform.m21;
+    if (determinant < 0) {
+      if (transform.m11 < transform.m22) scale.x = -scale.x;
+      else scale.y = -scale.y;
+    }
+    return {
+      position,
+      rotation,
+      scale,
+    };
+  }
+
+  private static *extractGroupNodes(
+    element: SVGElement,
+    svgRoot: Element,
+    parentTransform: DOMMatrix,
+    inheritedStyle: ShapeProps,
+  ): Generator<SVGShapeData> {
+    for (const child of element.children) {
+      if (!(child instanceof SVGGraphicsElement)) continue;
+
+      yield* this.extractElementNodes(
+        child,
+        svgRoot,
+        parentTransform,
+        inheritedStyle,
+      );
+    }
+  }
+
+  private static parseNumberAttribute(
+    element: SVGElement,
+    name: string,
+  ): number {
+    return parseFloat(element.getAttribute(name) ?? '0');
+  }
+
+  private static *extractElementNodes(
+    child: SVGGraphicsElement,
+    svgRoot: Element,
+    parentTransform: DOMMatrix,
+    inheritedStyle: ShapeProps,
+  ): Generator<SVGShapeData> {
+    const transformMatrix = SVG.getElementTransformation(
+      child,
+      parentTransform,
+    );
+    const style = SVG.getElementStyle(child, inheritedStyle);
+    const id = child.id ?? '';
+    if (child.tagName === 'g') {
+      yield* SVG.extractGroupNodes(child, svgRoot, transformMatrix, style);
+    } else if (child.tagName === 'use') {
+      const hrefElement = svgRoot.querySelector(
+        (child as SVGUseElement).href.baseVal,
+      )!;
+      if (!(hrefElement instanceof SVGGraphicsElement)) return;
+
+      yield* SVG.extractElementNodes(
+        hrefElement,
+        svgRoot,
+        transformMatrix,
+        inheritedStyle,
+      );
+    } else if (child.tagName === 'path') {
+      const data = child.getAttribute('d');
+      if (!data) {
+        useLogger().warn('blank path data at ' + child.id);
+        return;
+      }
+      const transformation = transformMatrix;
+      yield {
+        id: id || 'path',
+        type: Path as unknown as new (props: NodeProps) => Node,
+        props: {
+          data,
+          tweenAlignPath: true,
+          ...SVG.getMatrixTransformation(transformation),
+          ...style,
+        } as PathProps,
+      };
+    } else if (child.tagName === 'rect') {
+      const width = SVG.parseNumberAttribute(child, 'width');
+      const height = SVG.parseNumberAttribute(child, 'height');
+      const rx = SVG.parseNumberAttribute(child, 'rx');
+      const ry = SVG.parseNumberAttribute(child, 'ry');
+
+      const bbox = new BBox(0, 0, width, height);
+      const center = bbox.center;
+      const transformation = transformMatrix.translate(center.x, center.y);
+
+      yield {
+        id: id || 'rect',
+        type: Rect,
+        props: {
+          width,
+          height,
+          radius: [rx, ry],
+          ...SVG.getMatrixTransformation(transformation),
+          ...style,
+        } as RectProps,
+      };
+    } else if (['circle', 'ellipse'].includes(child.tagName)) {
+      const cx = SVG.parseNumberAttribute(child, 'cx');
+      const cy = SVG.parseNumberAttribute(child, 'cy');
+      const size: PossibleSpacing =
+        child.tagName === 'circle'
+          ? SVG.parseNumberAttribute(child, 'r') * 2
+          : [
+              SVG.parseNumberAttribute(child, 'rx') * 2,
+              SVG.parseNumberAttribute(child, 'ry') * 2,
+            ];
+
+      const transformation = transformMatrix.translate(cx, cy);
+
+      yield {
+        id: id || child.tagName,
+        type: Circle,
+        props: {
+          size,
+          ...style,
+          ...SVG.getMatrixTransformation(transformation),
+        } as CircleProps,
+      };
+    } else if (['line', 'polyline', 'polygon'].includes(child.tagName)) {
+      const numbers =
+        child.tagName === 'line'
+          ? ['x1', 'y1', 'x2', 'y2'].map(attr =>
+              SVG.parseNumberAttribute(child, attr),
+            )
+          : child
+              .getAttribute('points')!
+              .match(/-?[\d.e+-]+/g)!
+              .map(value => parseFloat(value));
+      const points = numbers.reduce<number[][]>((accum, current) => {
+        let last = accum.at(-1);
+        if (!last || last.length === 2) {
+          last = [];
+          accum.push(last);
+        }
+        last.push(current);
+        return accum;
+      }, []);
+
+      if (child.tagName === 'polygon') points.push(points[0]);
+
+      yield {
+        id: id || child.tagName,
+        type: Line as unknown as new (props: NodeProps) => Node,
+        props: {
+          points,
+          ...style,
+          ...SVG.getMatrixTransformation(transformMatrix),
+        } as LineProps,
+      };
+    } else if (child.tagName === 'image') {
+      const x = SVG.parseNumberAttribute(child, 'x');
+      const y = SVG.parseNumberAttribute(child, 'y');
+      const width = SVG.parseNumberAttribute(child, 'width');
+      const height = SVG.parseNumberAttribute(child, 'height');
+      const href = child.getAttribute('href') ?? '';
+
+      const bbox = new BBox(x, y, width, height);
+      const center = bbox.center;
+      const transformation = transformMatrix.translate(center.x, center.y);
+
+      yield {
+        id: id || child.tagName,
+        type: Img,
+        props: {
+          src: href,
+          ...style,
+          ...SVG.getMatrixTransformation(transformation),
+        } as ImgProps,
+      };
+    }
+  }
+
+  private getShapeMap(svg: SVGDocument) {
+    const map: Record<string, SVGDiffShape[]> = {};
+    for (const [index, node] of svg.nodes.entries()) {
+      if (!map[node.id]) map[node.id] = [];
+
+      map[node.id].push({index, node});
+    }
+    return map;
+  }
+
+  private diffSVG(from: SVGDocument, to: SVGDocument): SVGDiff {
+    const diff: SVGDiff = {
+      fromSize: from.size,
+      toSize: to.size,
+      inserted: [],
+      deleted: [],
+      transformed: [],
+    };
+
+    const fromMap = this.getShapeMap(from);
+    const fromKeys = Object.keys(fromMap);
+    const toMap = this.getShapeMap(to);
+    const toKeys = Object.keys(toMap);
+
+    while (fromKeys.length > 0) {
+      const key = fromKeys.pop()!;
+      const fromItem = fromMap[key];
+      const toIndex = toKeys.indexOf(key);
+      if (toIndex >= 0) {
+        toKeys.splice(toIndex, 1);
+        const toItem = toMap[key];
+
+        for (let i = 0; i < Math.max(fromItem.length, toItem.length); i++) {
+          const insert = i >= fromItem.length;
+          const deleted = i >= toItem.length;
+
+          const fromNode =
+            i < fromItem.length ? fromItem[i] : fromItem[fromItem.length - 1];
+          const toNode =
+            i < toItem.length ? toItem[i] : toItem[toItem.length - 1];
+
+          diff.transformed.push({
+            insert,
+            deleted,
+            from: fromNode,
+            to: toNode,
+          });
+        }
+      } else {
+        for (const node of fromItem) {
+          diff.deleted.push(node);
+        }
+      }
+    }
+
+    if (toKeys.length > 0) {
+      for (const key of toKeys) {
+        for (const node of toMap[key]) {
+          diff.inserted.push(node);
+        }
+      }
+    }
+
+    return diff;
+  }
+
+  private cloneNodeExact(node: Node) {
+    const props: ShapeProps = {
+      position: node.position(),
+      scale: node.scale(),
+      rotation: node.rotation(),
+      children: node.children().map(child => this.cloneNodeExact(child)),
+    };
+    if (node instanceof Layout) {
+      props.size = node.size();
+    }
+    return node.clone(props);
+  }
+
+  protected *generateTransformator(
+    from: Node,
+    to: Node,
+    time: number,
+    timing: TimingFunction,
+  ): Generator<ThreadGenerator> {
+    yield from.position(to.position(), time, timing);
+    yield from.scale(to.scale(), time, timing);
+    yield from.rotation(to.rotation(), time, timing);
+    if (
+      from instanceof Path &&
+      to instanceof Path &&
+      from.data() !== to.data()
+    ) {
+      yield from.data(to.data(), time, timing);
+    }
+    if (from instanceof Layout && to instanceof Layout) {
+      yield from.size(to.size(), time, timing);
+    }
+    if (from instanceof Shape && to instanceof Shape) {
+      yield from.fill(to.fill(), time, timing);
+      yield from.stroke(to.stroke(), time, timing);
+      yield from.lineWidth(to.lineWidth(), time, timing);
+    }
+
+    const fromChildren = from.children();
+    const toChildren = to.children();
+    for (let i = 0; i < fromChildren.length; i++) {
+      yield* this.generateTransformator(
+        fromChildren[i],
+        toChildren[i],
+        time,
+        timing,
+      );
+    }
+  }
+
+  private useTweenInitialNodes(diff: SVGDiff) {
+    const insertedList: SVGDiff['transformed'] = [];
+    for (const item of diff.transformed) {
+      if (!item.insert) continue;
+
+      const from = item.from;
+      item.from = {
+        index: from.index,
+        node: {
+          id: from.node.id,
+          shape: this.cloneNodeExact(from.node.shape),
+        },
+      };
+      insertedList.push(item);
+    }
+
+    const newChildren = this.wrapper.children().slice(0);
+    let insertShift = 0;
+
+    for (const {from} of insertedList.sort(
+      (a, b) => a.from.index - b.from.index,
+    )) {
+      newChildren.splice(from.index + insertShift, 0, from.node.shape);
+      from.node.shape.parent(this.wrapper);
+      insertShift++;
+    }
+
+    this.wrapper.children(newChildren);
+  }
+
+  private useTweenFinalNodes(diff: SVGDiff, newSVG: SVGDocument) {
+    const newChildren: Node[] = new Array(newSVG.nodes.length);
+    const deletedList: SVGDiff['transformed'] = [];
+
+    for (const item of diff.transformed) {
+      const {from, to, deleted} = item;
+      if (deleted) {
+        deletedList.push(item);
+        continue;
+      }
+      newChildren[to.index] = from.node.shape;
+      from.node.shape.parent(this.wrapper);
+    }
+    for (const {node, index} of diff.inserted) {
+      newChildren[index] = node.shape;
+      node.shape.parent(this.wrapper);
+    }
+
+    let insertShift = 0;
+    for (const {from, to} of deletedList.sort(
+      (a, b) => a.to.index - b.to.index,
+    )) {
+      newChildren.splice(to.index + insertShift, 0, from.node.shape);
+      from.node.shape.parent(this.wrapper);
+      insertShift++;
+    }
+
+    this.wrapper.children(newChildren);
+  }
+
+  @threadable()
+  protected *tweenSvg(
+    value: SignalValue<string>,
+    time: number,
+    timingFunction: TimingFunction,
+  ) {
+    const newValue = typeof value === 'string' ? value : value();
+    const newSVG = this.parseSVG(newValue);
+    const diff = this.diffSVG(this.document(), newSVG);
+
+    const beginning = 0.2;
+    const ending = 0.8;
+    const overlap = 0.15;
+
+    const transformator: ThreadGenerator[] = [];
+    const transformatorTime = (ending - beginning) * time;
+    const transformatorDelay = beginning * time;
+
+    this.useTweenInitialNodes(diff);
+
+    for (const transformed of diff.transformed) {
+      transformator.push(
+        ...this.generateTransformator(
+          transformed.from.node.shape,
+          transformed.to.node.shape,
+          transformatorTime,
+          timingFunction,
+        ),
+      );
+    }
+
+    let reordered = false;
+    const reorder = () => {
+      if (reordered) return;
+      this.useTweenFinalNodes(diff, newSVG);
+      reordered = true;
+    };
+
+    const autoWidth = this.width.isInitial();
+    const autoHeight = this.height.isInitial();
+
+    const baseTween = tween(
+      time,
+      value => {
+        const progress = timingFunction(value);
+        const remapped = clampRemap(beginning, ending, 0, 1, progress);
+
+        if (remapped >= 0.5) reorder();
+
+        const scale = this.wrapper.scale();
+        if (autoWidth) {
+          this.width(
+            easeInOutSine(remapped, diff.fromSize.x, diff.toSize.x) * scale.x,
+          );
+        }
+
+        if (autoHeight) {
+          this.height(
+            easeInOutSine(remapped, diff.fromSize.y, diff.toSize.y) * scale.y,
+          );
+        }
+
+        const deletedOpacity = clampRemap(
+          0,
+          beginning + overlap,
+          1,
+          0,
+          progress,
+        );
+        for (const {node} of diff.deleted) node.shape.opacity(deletedOpacity);
+
+        const insertedOpacity = clampRemap(ending - overlap, 1, 0, 1, progress);
+        for (const {node} of diff.inserted) node.shape.opacity(insertedOpacity);
+      },
+      () => {
+        this.wrapper.children(this.documentNodes);
+        if (autoWidth) this.width.reset();
+        if (autoHeight) this.height.reset();
+
+        for (const {node} of diff.deleted) node.shape.dispose();
+        for (const {from, to} of diff.transformed) {
+          from.node.shape.dispose();
+          to.node.shape.dispose();
+        }
+      },
+    );
+    yield* all(baseTween, delay(transformatorDelay, all(...transformator)));
+  }
+}

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -74,7 +74,7 @@ export interface SVGDocumentData {
 }
 
 export interface SVGProps extends ShapeProps {
-  svg?: SignalValue<string>;
+  svg: SignalValue<string>;
 }
 
 /**

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -400,8 +400,8 @@ export class SVG extends Shape {
     SVG.containerElement.innerHTML = svg;
 
     const svgRoot = SVG.containerElement.querySelector('svg')!;
-    let viewBox: BBox = new BBox();
-    let size: Vector2 = new Vector2();
+    let viewBox = new BBox();
+    let size = new Vector2();
 
     const hasViewBox = svgRoot.hasAttribute('viewBox');
     const hasSize =

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -406,19 +406,6 @@ export class SVG extends Shape {
     }
   }
 
-  private cloneNodeExact(node: Node) {
-    const props: ShapeProps = {
-      position: node.position(),
-      scale: node.scale(),
-      rotation: node.rotation(),
-      children: node.children().map(child => this.cloneNodeExact(child)),
-    };
-    if (node instanceof Layout) {
-      props.size = node.size();
-    }
-    return node.clone(props);
-  }
-
   protected *generateTransformator(
     from: Node,
     to: Node,
@@ -472,7 +459,7 @@ export class SVG extends Shape {
       diff,
       ({shape, ...rest}) => ({
         ...rest,
-        shape: this.cloneNodeExact(shape),
+        shape: shape.clone(),
       }),
     );
     this.wrapper.children(currentSVG.nodes.map(shape => shape.shape));

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -493,12 +493,7 @@ export class SVG extends Shape {
     color: SignalValue<PossibleCanvasStyle> | undefined,
   ): SignalValue<PossibleCanvasStyle> | undefined {
     if (color === 'transparent' || color === 'none') {
-      return {
-        r: 0,
-        g: 0,
-        b: 0,
-        a: 0,
-      };
+      return null;
     }
 
     return color;

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -201,26 +201,26 @@ export class SVG extends Shape {
   protected *generateTransformer(
     from: Node,
     to: Node,
-    duration : number,
+    duration: number,
     timing: TimingFunction,
   ): Generator<ThreadGenerator> {
-    yield from.position(to.position(), time, timing);
-    yield from.scale(to.scale(), time, timing);
-    yield from.rotation(to.rotation(), time, timing);
+    yield from.position(to.position(), duration, timing);
+    yield from.scale(to.scale(), duration, timing);
+    yield from.rotation(to.rotation(), duration, timing);
     if (
       from instanceof Path &&
       to instanceof Path &&
       from.data() !== to.data()
     ) {
-      yield from.data(to.data(), time, timing);
+      yield from.data(to.data(), duration, timing);
     }
     if (from instanceof Layout && to instanceof Layout) {
-      yield from.size(to.size(), time, timing);
+      yield from.size(to.size(), duration, timing);
     }
     if (from instanceof Shape && to instanceof Shape) {
-      yield from.fill(to.fill(), time, timing);
-      yield from.stroke(to.stroke(), time, timing);
-      yield from.lineWidth(to.lineWidth(), time, timing);
+      yield from.fill(to.fill(), duration, timing);
+      yield from.stroke(to.stroke(), duration, timing);
+      yield from.lineWidth(to.lineWidth(), duration, timing);
     }
 
     const fromChildren = from.children();
@@ -229,7 +229,7 @@ export class SVG extends Shape {
       yield* this.generateTransformer(
         fromChildren[i],
         toChildren[i],
-        time,
+        duration,
         timing,
       );
     }

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -1,4 +1,8 @@
-import {SignalValue, SimpleSignal} from '@motion-canvas/core/lib/signals';
+import {
+  SignalValue,
+  SimpleSignal,
+  isReactive,
+} from '@motion-canvas/core/lib/signals';
 import {
   BBox,
   Matrix2D,
@@ -213,7 +217,7 @@ export class SVG extends Shape {
     time: number,
     timingFunction: TimingFunction,
   ) {
-    const newValue = typeof value === 'string' ? value : value();
+    const newValue = isReactive(value) ? value() : value;
     const newSVG = this.parseSVG(newValue);
     const currentSVG = this.document();
     const diff = getTransformDiff(currentSVG.nodes, newSVG.nodes);

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -1,6 +1,7 @@
 import {SignalValue, SimpleSignal} from '@motion-canvas/core/lib/signals';
 import {
   BBox,
+  Matrix2D,
   PossibleSpacing,
   SerializedVector2,
   Vector2,
@@ -409,19 +410,17 @@ export class SVG extends Shape {
    * @returns MotionCanvas Shape properties
    */
   protected static getMatrixTransformation(transform: DOMMatrix): ShapeProps {
-    const position = {
-      x: transform.m41,
-      y: transform.m42,
-    };
-    const rotation = (Math.atan2(transform.m12, transform.m11) * 180) / Math.PI;
+    const matrix2 = new Matrix2D(transform);
+
+    const position = matrix2.translation;
+    const rotation = matrix2.rotation;
+    // matrix.scaling can give incorrect result when matrix contain skew operation
     const scale = {
-      x: Vector2.magnitude(transform.m11, transform.m12),
-      y: Vector2.magnitude(transform.m21, transform.m22),
+      x: matrix2.x.magnitude,
+      y: matrix2.y.magnitude,
     };
-    const determinant =
-      transform.m11 * transform.m22 - transform.m12 * transform.m21;
-    if (determinant < 0) {
-      if (transform.m11 < transform.m22) scale.x = -scale.x;
+    if (matrix2.determinant < 0) {
+      if (matrix2.values[0] < matrix2.values[3]) scale.x = -scale.x;
       else scale.y = -scale.y;
     }
     return {

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -399,7 +399,19 @@ export class SVG extends Shape {
 
     SVG.containerElement.innerHTML = svg;
 
-    const svgRoot = SVG.containerElement.querySelector('svg')!;
+    const svgRoot = SVG.containerElement.querySelector('svg');
+
+    if (!svgRoot) {
+      useLogger().error({
+        message: 'Invalid SVG',
+        object: svg,
+      });
+      return {
+        size: new Vector2(0, 0),
+        nodes: [],
+      } as SVGDocumentData;
+    }
+
     let viewBox = new BBox();
     let size = new Vector2();
 

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -174,7 +174,7 @@ export class SVG extends Shape {
    * @param time - time for tweening
    * @param timing - timing for tweening
    */
-  protected *generateTransformator(
+  protected *generateTransformer(
     from: Node,
     to: Node,
     time: number,
@@ -202,7 +202,7 @@ export class SVG extends Shape {
     const fromChildren = from.children();
     const toChildren = to.children();
     for (let i = 0; i < fromChildren.length; i++) {
-      yield* this.generateTransformator(
+      yield* this.generateTransformer(
         fromChildren[i],
         toChildren[i],
         time,
@@ -248,7 +248,7 @@ export class SVG extends Shape {
 
     for (const item of diff.transformed) {
       transformator.push(
-        ...this.generateTransformator(
+        ...this.generateTransformer(
           item.from.current.shape,
           item.to.current.shape,
           transformatorTime,

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -251,17 +251,13 @@ export class SVG extends Shape {
     this.lastTweenTargetSrc = newValue;
     this.lastTweenTargetDocument = newSVG;
 
-    const applyResult = applyTransformDiff(
-      currentSVG.nodes,
-      diff,
-      ({shape, ...rest}) => ({
-        ...rest,
-        shape: shape.clone(),
-      }),
-    );
+    applyTransformDiff(currentSVG.nodes, diff, ({shape, ...rest}) => ({
+      ...rest,
+      shape: shape.clone(),
+    }));
     this.wrapper.children(currentSVG.nodes.map(shape => shape.shape));
-    for (const {item} of applyResult.inserted) {
-      item.current.shape.parent(this.wrapper);
+    for (const item of currentSVG.nodes) {
+      item.shape.parent(this.wrapper);
     }
 
     const beginning = 0.2;

--- a/packages/2d/src/components/SVG.ts
+++ b/packages/2d/src/components/SVG.ts
@@ -540,7 +540,7 @@ export class SVG extends Shape {
     if (!value) return null;
 
     const list = value.split(/,|\s+/);
-    if (list.findIndex(str => str.endsWith('%'))) {
+    if (list.findIndex(str => str.endsWith('%')) > 0) {
       useLogger().warn(`SVG: percentage line dash are ignored`);
       return null;
     }

--- a/packages/2d/src/components/index.ts
+++ b/packages/2d/src/components/index.ts
@@ -17,6 +17,7 @@ export * from './Path';
 export * from './QuadBezier';
 export * from './Shape';
 export * from './Spline';
+export * from './SVG';
 export * from './Txt';
 export * from './types';
 export * from './Video';

--- a/packages/2d/src/utils/diff.test.ts
+++ b/packages/2d/src/utils/diff.test.ts
@@ -1,0 +1,369 @@
+import {describe, expect, it} from 'vitest';
+import {applyTransformDiff, getTransformDiff} from './diff';
+
+describe('diff', () => {
+  it('Insert single item', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '4',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    applyTransformDiff(from, diff, ({id}) => ({id}));
+    expect(from).toEqual(to);
+  });
+
+  it('Insert single item when contain have two item with equal', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '1',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '4',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '1',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    applyTransformDiff(from, diff, ({id}) => ({id}));
+    expect(from).toEqual(to);
+  });
+  it('Insert multiple item', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '1',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '7',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '4',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '9',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    applyTransformDiff(from, diff, ({id}) => ({id}));
+    expect(from).toEqual(to);
+  });
+  it('Insert single item with equal id', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    expect(diff.inserted).toEqual([]);
+    applyTransformDiff(from, diff, ({id}) => ({id}));
+    expect(from).toEqual(to);
+  });
+  it('Insert multiple item with equal id', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '1',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    expect(diff.inserted).toEqual([]);
+    applyTransformDiff(from, diff, ({id}) => ({id}));
+    expect(from).toEqual(to);
+  });
+  it('Delete single item', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    expect(diff.deleted.map(({current}) => current)).toEqual([
+      {
+        id: '2',
+      },
+    ]);
+  });
+  it('Delete multiple item', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    expect(diff.deleted.map(({current}) => current)).toEqual([
+      {
+        id: '3',
+      },
+      {
+        id: '2',
+      },
+    ]);
+  });
+  it('Delete single item with equal id', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '1',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    expect(diff.deleted).toEqual([]);
+    expect(diff.transformed).toContainEqual({
+      from: {
+        before: {
+          id: '3',
+        },
+        beforeIdIndex: 0,
+        current: {
+          id: '1',
+        },
+      },
+      insert: false,
+      remove: true,
+      to: {
+        before: undefined,
+        beforeIdIndex: -1,
+        current: {
+          id: '1',
+        },
+      },
+    });
+  });
+  it('Delete single item with equal id', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '1',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    expect(diff.deleted).toEqual([]);
+    expect(diff.transformed).toContainEqual({
+      from: {
+        before: {
+          id: '2',
+        },
+        beforeIdIndex: 0,
+        current: {
+          id: '1',
+        },
+      },
+      insert: false,
+      remove: true,
+      to: {
+        before: undefined,
+        beforeIdIndex: -1,
+        current: {
+          id: '1',
+        },
+      },
+    });
+    expect(diff.transformed).toContainEqual({
+      from: {
+        before: {
+          id: '3',
+        },
+        beforeIdIndex: 0,
+        current: {
+          id: '1',
+        },
+      },
+      insert: false,
+      remove: true,
+      to: {
+        before: undefined,
+        beforeIdIndex: -1,
+        current: {
+          id: '1',
+        },
+      },
+    });
+  });
+});

--- a/packages/2d/src/utils/diff.test.ts
+++ b/packages/2d/src/utils/diff.test.ts
@@ -366,4 +366,48 @@ describe('diff', () => {
       },
     });
   });
+
+  it('Insert single item with moving', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '5',
+      },
+      {
+        id: '2',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    applyTransformDiff(from, diff, ({id}) => ({id}));
+    expect(from).toEqual([
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+      {
+        id: '5',
+      },
+    ]);
+  });
 });

--- a/packages/2d/src/utils/diff.test.ts
+++ b/packages/2d/src/utils/diff.test.ts
@@ -238,10 +238,10 @@ describe('diff', () => {
     const diff = getTransformDiff(from, to);
     expect(diff.deleted.map(({current}) => current)).toEqual([
       {
-        id: '3',
+        id: '2',
       },
       {
-        id: '2',
+        id: '3',
       },
     ]);
   });

--- a/packages/2d/src/utils/diff.test.ts
+++ b/packages/2d/src/utils/diff.test.ts
@@ -282,6 +282,7 @@ describe('diff', () => {
         current: {
           id: '1',
         },
+        currentIndex: 3,
       },
       insert: false,
       remove: true,
@@ -291,6 +292,7 @@ describe('diff', () => {
         current: {
           id: '1',
         },
+        currentIndex: 0,
       },
     });
   });
@@ -334,6 +336,7 @@ describe('diff', () => {
         current: {
           id: '1',
         },
+        currentIndex: 2,
       },
       insert: false,
       remove: true,
@@ -343,6 +346,7 @@ describe('diff', () => {
         current: {
           id: '1',
         },
+        currentIndex: 0,
       },
     });
     expect(diff.transformed).toContainEqual({
@@ -354,6 +358,7 @@ describe('diff', () => {
         current: {
           id: '1',
         },
+        currentIndex: 4,
       },
       insert: false,
       remove: true,
@@ -363,6 +368,7 @@ describe('diff', () => {
         current: {
           id: '1',
         },
+        currentIndex: 0,
       },
     });
   });
@@ -409,5 +415,39 @@ describe('diff', () => {
         id: '5',
       },
     ]);
+  });
+
+  it('Insert item after transformed insert', () => {
+    const from = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const to = [
+      {
+        id: '1',
+      },
+      {
+        id: '2',
+      },
+      {
+        id: '1',
+      },
+      {
+        id: '4',
+      },
+      {
+        id: '3',
+      },
+    ];
+    const diff = getTransformDiff(from, to);
+    applyTransformDiff(from, diff, ({id}) => ({id}));
+    expect(from).toEqual(to);
   });
 });

--- a/packages/2d/src/utils/diff.ts
+++ b/packages/2d/src/utils/diff.ts
@@ -1,0 +1,138 @@
+interface TransformDiff<T> {
+  inserted: TransformDiffItem<T>[];
+  deleted: TransformDiffItem<T>[];
+  transformed: TransformDiffItemTransformed<T>[];
+}
+
+interface TransformDiffItem<T> {
+  before?: T;
+  current: T;
+  beforeIdIndex: number;
+}
+
+interface TransformDiffItemTransformed<T> {
+  insert: boolean;
+  remove: boolean;
+  from: TransformDiffItem<T>;
+  to: TransformDiffItem<T>;
+}
+
+interface ApplyTransformResult<T> {
+  inserted: TransformDiffItem<T>[];
+}
+
+interface Idable {
+  id: string;
+}
+
+function getIdMap<T extends Idable>(list: T[]) {
+  const map: Record<string, TransformDiffItem<T>[]> = {};
+  let before: T | undefined = undefined;
+  for (const current of list) {
+    if (!map[current.id]) map[current.id] = [];
+
+    map[current.id].push({
+      before,
+      current,
+      beforeIdIndex: before ? map[before.id].length - 1 : -1,
+    });
+    before = current;
+  }
+  return map;
+}
+
+export function getTransformDiff<T extends Idable>(
+  from: T[],
+  to: T[],
+): TransformDiff<T> {
+  const diff: TransformDiff<T> = {
+    inserted: [],
+    deleted: [],
+    transformed: [],
+  };
+
+  const fromMap = getIdMap(from);
+  const fromKeys = Object.keys(fromMap);
+  const toMap = getIdMap(to);
+  const toKeys = Object.keys(toMap);
+
+  while (fromKeys.length > 0) {
+    const key = fromKeys.pop()!;
+    const fromItem = fromMap[key];
+    const toIndex = toKeys.indexOf(key);
+    if (toIndex >= 0) {
+      toKeys.splice(toIndex, 1);
+      const toItem = toMap[key];
+
+      for (let i = 0; i < Math.max(fromItem.length, toItem.length); i++) {
+        const insert = i >= fromItem.length;
+        const remove = i >= toItem.length;
+
+        const fromNode = !insert ? fromItem[i] : fromItem[fromItem.length - 1];
+        const toNode = !remove ? toItem[i] : toItem[toItem.length - 1];
+
+        diff.transformed.push({
+          insert,
+          remove,
+          from: fromNode,
+          to: toNode,
+        });
+      }
+    } else {
+      for (const node of fromItem) {
+        diff.deleted.push(node);
+      }
+    }
+  }
+
+  if (toKeys.length > 0) {
+    for (const key of toKeys) {
+      for (const node of toMap[key]) {
+        diff.inserted.push(node);
+      }
+    }
+  }
+
+  return diff;
+}
+
+export function applyTransformDiff<T extends Idable>(
+  current: T[],
+  diff: TransformDiff<T>,
+  cloner: (original: T) => T,
+): ApplyTransformResult<T> {
+  const result: ApplyTransformResult<T> = {
+    inserted: [],
+  };
+  function insert(item: TransformDiffItem<T>) {
+    result.inserted.push(item);
+    let idIndex = -1;
+    const index = item.before
+      ? current.findIndex(({id}) => {
+          if (id === item.before?.id) {
+            idIndex++;
+            if (idIndex === item.beforeIdIndex) return true;
+          }
+          return false;
+        })
+      : 0;
+    current.splice(index + 1, 0, item.current);
+  }
+
+  for (const item of diff.inserted) {
+    insert(item);
+  }
+
+  for (const item of diff.transformed) {
+    if (!item.insert) continue;
+
+    const from = item.from;
+    item.from = {
+      ...item.to,
+      current: cloner(from.current),
+    };
+    insert(item.from);
+  }
+
+  return result;
+}

--- a/packages/2d/src/utils/diff.ts
+++ b/packages/2d/src/utils/diff.ts
@@ -35,9 +35,8 @@ function getIdMap<T extends Idable>(list: T[]) {
   const map = new Map<string, TransformDiffItem<T>[]>();
   let before: T | undefined = undefined;
   for (const [index, current] of list.entries()) {
-    let currentArray = map.get(current.id);
-    if (!currentArray) {
-      currentArray = [];
+    const currentArray = map.get(current.id) ?? [];
+    if (!map.has(current.id)) {
       map.set(current.id, currentArray);
     }
 


### PR DESCRIPTION
This will add `SVG` component. This component can render SVG and tween between two SVG.

This is part of [add Latex component pull request](https://github.com/motion-canvas/motion-canvas/pull/539).

## Tweening Algorithm

SVG tweening algorithm support insertion, deletion and tranformation. This algorithm is based on [ManimCommunity TransformMatchingShapes](https://github.com/ManimCommunity/manim/blob/main/manim/animation/transform_matching_parts.py)

This algorithm also support SVG that contain 2 or more element with same id. When number of element with some id in source and target do not match, all element will be transformed wihout insertion or deletion. 

When number of element with some id in source is greater than number of element with that id then excess element will be transformed into target last element with that id.

```
[1, 2, 1, 3, 1] -> [1, 2, 3]
```

> Second and third source element with id 1 will be transformed into first target element with id 1.

When number of element with some id in source is lower than number of element with that id then source last element with that id will be cloned and then transformed target element that index is matched.

```
[1, 2, 3] --> [1, 2, 1, 3, 1]
```

> First source element with id 1 will cloned two time and the two item will transformed to second and third target element with id 1 respectively

This algorithm does not support moving item index. Why? Because moving item index cannot transformed/animated smoothly.

This algorithm will insert element based on previous element not index. Why? For simplicity. When, there are inserted element and element previous item is moved then the element will inserted after previous item.

```
[1, 2, 3] --> [1, 3, 5, 2]

result: [1,2,3,5]
```
> 5 is after 3, 5 is inserted after 3. 
