### PR TITLE
fix(2d): Curve click area bigger than actual area

### DIFF
--- a/packages/2d/src/components/Curve.ts
+++ b/packages/2d/src/components/Curve.ts
@@ -373,7 +373,8 @@ export abstract class Curve extends Shape {
 
   protected override getCacheBBox(): BBox {
     const box = this.childrenBBox();
-    const arrowSize = this.arrowSize();
+    const arrowSize =
+      this.startArrow() || this.endArrow() ? this.arrowSize() : 0;
     const lineWidth = this.lineWidth();
 
     const coefficient = this.lineWidthCoefficient();


### PR DESCRIPTION
This issue is caused by `getCacheBBox` in Curve component always consider `arrowSize` even when arrow is not drawn. This make Curve click area is 24px bigger than actual area. This will get worse when the component has scale. For example, when component have scale 5, then click area is 24px*5 or 120px bigger than actual area.

Before this PR:

https://github.com/motion-canvas/motion-canvas/assets/42236775/2930ebe4-2faa-44eb-9cb0-2313cac09259

After this PR:

https://github.com/motion-canvas/motion-canvas/assets/42236775/dd7204ee-fe00-42db-974c-c3692fb50c83

