### PR TITLE
docs: consistency of phrasing for relative positioning of nodes

### DIFF
--- a/packages/docs/docs/getting-started/positioning.mdx
+++ b/packages/docs/docs/getting-started/positioning.mdx
@@ -16,7 +16,7 @@ down.
 
 ## Transform
 
-All nodes are positioned relatively to their parents. This means that any
+All nodes are positioned relative to their parents. This means that any
 transformations applied to the parent are also applied to its children. The
 transform of each node consists of the following properties:
 


### PR DESCRIPTION
This is a small change to phrasing in the docs that substitutes the phrase "relatively to"  with "relative to".

The latter is more conventional/idiomatic and is also consistent with similar usage contexts in the rest of the docs.

The purpose of the change is to minimise any ambiguity for the user when interpreting the technical content.