### PR TITLE
Fix OUTPUT DIRECTORY button on WSL

### DIFF
--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -383,6 +383,9 @@ export default ({
         }
 
         if (name === '__open-output-path') {
+          if (!fs.existsSync(outputPath)) {
+            fs.mkdirSync(outputPath, {recursive: true});
+          }
           openInExplorer(outputPath);
           res.end();
           return;

--- a/packages/vite-plugin/src/openInExplorer.ts
+++ b/packages/vite-plugin/src/openInExplorer.ts
@@ -1,4 +1,4 @@
-import {spawn} from 'child_process';
+import {execSync, spawn} from 'child_process';
 import {platform} from 'os';
 import {existsSync, mkdirSync} from 'fs';
 
@@ -15,16 +15,33 @@ export function openInExplorer(file: string) {
       explorer = 'explorer';
       break;
     case 'linux':
-      explorer = 'xdg-open';
+      if (isRunningOnWSL()) {
+        explorer = 'bash';
+        file = `cd ${file} && explorer.exe .`;
+      } else {
+        explorer = 'xdg-open';
+      }
       break;
     case 'darwin':
       explorer = 'open';
       break;
   }
 
-  if (explorer) {
+  if (explorer === 'bash') {
+    spawn(explorer, ['-c', file], {detached: true}).unref();
+  } else if (explorer) {
     spawn(explorer, [file], {detached: true}).unref();
   } else {
     console.warn(`Unsupported OS: ${os}`);
+  }
+}
+
+function isRunningOnWSL(): boolean {
+  try {
+    const uname = execSync('uname -a').toString().toLowerCase();
+    return uname.includes('microsoft');
+  } catch (error) {
+    console.error(`exec error: ${error}`);
+    return false;
   }
 }

--- a/packages/vite-plugin/src/openInExplorer.ts
+++ b/packages/vite-plugin/src/openInExplorer.ts
@@ -1,36 +1,30 @@
 import {execSync, spawn} from 'child_process';
 import {platform} from 'os';
-import {existsSync, mkdirSync} from 'fs';
 
 export function openInExplorer(file: string) {
-  let explorer: string | null = null;
+  let command: string | null = null;
+  let args = [file];
   const os = platform();
-
-  if (!existsSync(file)) {
-    mkdirSync(file, {recursive: true});
-  }
 
   switch (os) {
     case 'win32':
-      explorer = 'explorer';
+      command = 'explorer';
       break;
     case 'linux':
       if (isRunningOnWSL()) {
-        explorer = 'bash';
-        file = `cd ${file} && explorer.exe .`;
+        command = 'bash';
+        args = ['-c', `cd ${file} && explorer.exe .`];
       } else {
-        explorer = 'xdg-open';
+        command = 'xdg-open';
       }
       break;
     case 'darwin':
-      explorer = 'open';
+      command = 'open';
       break;
   }
 
-  if (explorer === 'bash') {
-    spawn(explorer, ['-c', file], {detached: true}).unref();
-  } else if (explorer) {
-    spawn(explorer, [file], {detached: true}).unref();
+  if (command) {
+    spawn(command, args, {detached: true}).unref();
   } else {
     console.warn(`Unsupported OS: ${os}`);
   }

--- a/packages/vite-plugin/src/openInExplorer.ts
+++ b/packages/vite-plugin/src/openInExplorer.ts
@@ -1,9 +1,15 @@
 import {spawn} from 'child_process';
 import {platform} from 'os';
+import {existsSync, mkdirSync} from 'fs';
 
 export function openInExplorer(file: string) {
   let explorer: string | null = null;
   const os = platform();
+
+  if (!existsSync(file)) {
+    mkdirSync(file, {recursive: true});
+  }
+
   switch (os) {
     case 'win32':
       explorer = 'explorer';


### PR DESCRIPTION
This is a PR regarding the OUTPUT DIRECTORY button located in the player's video settings.

When we run `npm` on WSL (Windows Subsystem for Linux) then Motion Canvas tries to execute:
`xdg-open <absolute-path-to-output-dir>`

In the case of WSL it won't work, so we can do something like this:
`bash -c cd <absolute-path-to-output-dir> && explorer.exe .`