### PR TITLE
build: remove `baseUrl` option

### DIFF
--- a/packages/2d/src/decorators/defaultStyle.ts
+++ b/packages/2d/src/decorators/defaultStyle.ts
@@ -1,5 +1,5 @@
 import {capitalize} from '@motion-canvas/core/lib/utils';
-import {Layout} from 'components';
+import {Layout} from '../components';
 
 export function defaultStyle<T>(
   styleName: string,

--- a/packages/2d/tsconfig.json
+++ b/packages/2d/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "outDir": "lib",
     "strict": true,
     "noImplicitOverride": true,
@@ -12,12 +11,7 @@
     "declarationMap": true,
     "inlineSourceMap": true,
     "experimentalDecorators": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "@motion-canvas/2d/lib",
     "skipLibCheck": true,
-    "paths": {
-      "@motion-canvas/2d/lib/jsx-runtime": ["jsx-runtime.ts"]
-    },
     "types": ["node"],
     "plugins": [
       {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "outDir": "lib",
     "inlineSourceMap": true,
     "noImplicitAny": true,
@@ -14,11 +13,6 @@
     "declarationMap": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "@motion-canvas/core/lib",
-    "paths": {
-      "@motion-canvas/core/lib/jsx-runtime": ["jsx-runtime.ts"]
-    },
     "plugins": [
       {
         "transform": "@motion-canvas/internal/transformers/markdown-literals.js"

--- a/packages/create/template-2d-ts/tsconfig.json
+++ b/packages/create/template-2d-ts/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@motion-canvas/2d/tsconfig.project.json",
-  "compilerOptions": {
-    "baseUrl": "src"
-  },
   "include": ["src"]
 }

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@motion-canvas/2d/tsconfig.project.json",
-  "compilerOptions": {
-    "baseUrl": "src"
-  },
   "include": ["src"]
 }

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@motion-canvas/2d/tsconfig.project.json",
-  "compilerOptions": {
-    "baseUrl": "src"
-  },
   "include": ["src"]
 }

--- a/packages/template/tsconfig.json
+++ b/packages/template/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@motion-canvas/2d/tsconfig.project.json",
   "compilerOptions": {
-    "baseUrl": "src",
     "types": ["node"]
   },
   "include": ["src"]

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "outDir": "lib",
     "strict": true,
     "module": "commonjs",


### PR DESCRIPTION
`baseUrl` is used to declare the base directory for resolving non-relative module paths. Our tooling is not configured to support that feature and so the option is not necessary.

Some IDE consider the presence of this option as a hint to use absolute paths for auto imports. Removing it should fix that issue.