### PR TITLE
fix: for handling unusual characters in file names

### DIFF
--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -317,7 +317,8 @@ export default ({
       }
 
       if (ext === '.meta') {
-        const sourceFile = viteConfig.command === 'build' ? false : `'${id}'`;
+        const sourceFile =
+          viteConfig.command === 'build' ? false : JSON.stringify(id);
         return source(
           `import {MetaFile} from '@motion-canvas/core/lib/meta';`,
           `let meta;`,


### PR DESCRIPTION
This fix is for solving issue [#764](https://github.com/motion-canvas/motion-canvas/issues/764) and any others that might be caused if the user's folder names include unusual characters which might be considered invalid by JS.