### PR TITLE
feat(core): seek to beginning of timeline in disable loop mode

### DIFF
--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -338,14 +338,15 @@ export class Player {
     }
 
     // Pause if reached the end or the range is 0
-    // Seek to the beginning
+    // Seek to the beginning for non-empty scenes
     if (
       (!state.loop && this.finished && !state.paused && state.seek < 0) ||
       this.endFrame === this.startFrame
     ) {
       this.togglePlayback(false);
       state.paused = true;
-      state.seek = this.startFrame;
+      state.seek =
+        this.endFrame === this.startFrame ? state.seek : this.startFrame;
     }
 
     // Seek to the beginning if looping is enabled

--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -338,12 +338,14 @@ export class Player {
     }
 
     // Pause if reached the end or the range is 0
+    // Seek to the beginning
     if (
       (!state.loop && this.finished && !state.paused && state.seek < 0) ||
       this.endFrame === this.startFrame
     ) {
       this.togglePlayback(false);
       state.paused = true;
+      state.seek = this.startFrame;
     }
 
     // Seek to the beginning if looping is enabled


### PR DESCRIPTION
For disable loop mode, this enhancement will seek to the beginning of timeline. Also, this behavior can now be observed for the case where user may hide the timeline. The feature is in line with latest video/animation editors, and hence is made to fit its intuitive usage. 

Closes https://github.com/motion-canvas/motion-canvas/issues/822