### PR TITLE
feat(2d): add playbackRate signal to Video component

### DIFF
--- a/packages/2d/src/components/__logs__/reactive-playback-rate.md
+++ b/packages/2d/src/components/__logs__/reactive-playback-rate.md
@@ -1,0 +1,19 @@
+The `playbackRate` of a `Video` cannot be reactive.
+
+Make sure to use a concrete value and not a function:
+
+```ts
+// wrong ✗
+video.playbackRate(() => 7);
+// correct ✓
+video.playbackRate(7);
+```
+
+If you're using a signal, extract its value before passing it to the property:
+
+```ts
+// wrong ✗
+video.playbackRate(mySignal);
+// correct ✓
+video.playbackRate(mySignal());
+```


### PR DESCRIPTION
Added a `playbackRate` signal to the Video component that mirrors [`HTMLMediaElement.playbackRate`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playbackRate).

Solves #711.