### PR TITLE
feat(core): allow ordering of scenes during transition

### DIFF
--- a/packages/core/src/app/Stage.ts
+++ b/packages/core/src/app/Stage.ts
@@ -2,6 +2,7 @@ import {getContext} from '../utils';
 import {Scene} from '../scenes';
 import {CanvasColorSpace, Vector2} from '../types';
 import type {Color} from '../types';
+import {unwrap} from '../signals';
 
 export interface StageSettings {
   size: Vector2;
@@ -75,6 +76,10 @@ export class Stage {
   }
 
   public async render(currentScene: Scene, previousScene: Scene | null) {
+    const previousOnTop = previousScene
+      ? unwrap(currentScene.previousOnTop)
+      : false;
+
     if (previousScene) {
       this.transformCanvas(this.previousContext);
       await previousScene.render(this.previousContext);
@@ -92,10 +97,13 @@ export class Stage {
       this.context.restore();
     }
 
-    if (previousScene) {
+    if (previousScene && !previousOnTop) {
       this.context.drawImage(this.previousBuffer, 0, 0);
     }
     this.context.drawImage(this.currentBuffer, 0, 0);
+    if (previousOnTop) {
+      this.context.drawImage(this.previousBuffer, 0, 0);
+    }
   }
 
   public transformCanvas(context: CanvasRenderingContext2D) {

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -23,7 +23,7 @@ import {Threadable} from './Threadable';
 import {BBox, Vector2} from '../types';
 import {SceneState} from './SceneState';
 import {Random} from './Random';
-import {DependencyContext} from '../signals';
+import {DependencyContext, SignalValue} from '../signals';
 import {SceneMetadata} from './SceneMetadata';
 import {Slides} from './Slides';
 
@@ -48,6 +48,7 @@ export abstract class GeneratorScene<T>
   public readonly variables: Variables;
   public random: Random;
   public creationStack?: string;
+  public previousOnTop: SignalValue<boolean>;
 
   public get firstFrame() {
     return this.cache.current.firstFrame;
@@ -134,6 +135,7 @@ export abstract class GeneratorScene<T>
     this.slides = new Slides(this);
 
     this.random = new Random(this.meta.seed.get());
+    this.previousOnTop = false;
   }
 
   public abstract getView(): T;
@@ -271,6 +273,7 @@ export abstract class GeneratorScene<T>
   public async reset(previousScene: Scene | null = null) {
     this.counters = {};
     this.previousScene = previousScene;
+    this.previousOnTop = false;
     this.random = new Random(this.meta.seed.get());
     this.runner = threads(
       () => this.runnerFactory(this.getView()),

--- a/packages/core/src/scenes/Scene.ts
+++ b/packages/core/src/scenes/Scene.ts
@@ -11,6 +11,7 @@ import type {LifecycleEvents} from './LifecycleEvents';
 import type {Random} from './Random';
 import type {SceneMetadata} from './SceneMetadata';
 import type {Slides} from './Slides';
+import type {SignalValue} from '../signals';
 
 /**
  * The constructor used when creating new scenes.
@@ -301,4 +302,9 @@ export interface Scene<T = unknown> {
    * Should always return `true`.
    */
   isCached(): boolean;
+
+  /**
+   * Should this scene be rendered below the previous scene during a transition?
+   */
+  previousOnTop: SignalValue<boolean>;
 }

--- a/packages/core/src/transitions/useTransition.ts
+++ b/packages/core/src/transitions/useTransition.ts
@@ -1,3 +1,4 @@
+import {SignalValue} from '../signals/types';
 import {useScene} from '../utils';
 
 /**
@@ -5,10 +6,12 @@ import {useScene} from '../utils';
  *
  * @param current - The callback to use before the current scene is rendered.
  * @param previous - The callback to use before the previous scene is rendered.
+ * @param previousOnTop - Whether the previous scene should be rendered on top.
  */
 export function useTransition(
   current: (ctx: CanvasRenderingContext2D) => void,
   previous?: (ctx: CanvasRenderingContext2D) => void,
+  previousOnTop?: SignalValue<boolean>,
 ) {
   if (previous == null) {
     previous = () => {
@@ -18,6 +21,7 @@ export function useTransition(
 
   const scene = useScene();
   const prior = scene.previous;
+  scene.previousOnTop = previousOnTop ?? false;
 
   const unsubPrev = prior?.lifecycleEvents.onBeforeRender.subscribe(previous);
   const unsubNext = scene.lifecycleEvents.onBeforeRender.subscribe(current);


### PR DESCRIPTION
This PR adds a third argument to `useTransition`, which is a boolean or signal indicating whether the previous scene is rendered on top of the current scene during the transition.

Solves #369.