### PR TITLE
feat(ui): small improvements

### DIFF
--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -205,6 +205,24 @@ export class Player {
     }
   }
 
+  /**
+   * Whether the given frame is inside the animation range.
+   *
+   * @param frame - The frame to check.
+   */
+  public isInRange(frame: number): boolean {
+    return frame >= 0 && frame <= this.playback.duration;
+  }
+
+  /**
+   * Whether the given frame is inside the user-defined range.
+   *
+   * @param frame - The frame to check.
+   */
+  public isInUserRange(frame: number): boolean {
+    return frame >= this.startFrame && frame <= this.endFrame;
+  }
+
   public requestSeek(value: number): void {
     this.requestedSeek = this.clampRange(value);
   }
@@ -374,7 +392,7 @@ export class Player {
       : PlaybackState.Playing;
 
     // Seek to the given frame
-    if (state.seek >= 0 || !this.isInRange(this.status.frame)) {
+    if (state.seek >= 0 || !this.isInUserRange(this.status.frame)) {
       const seekFrame = state.seek < 0 ? this.status.frame : state.seek;
       const clampedFrame = this.clampRange(seekFrame);
       this.logger.profile('seek time');
@@ -460,10 +478,6 @@ export class Player {
 
   private clampRange(frame: number): number {
     return clamp(this.startFrame, this.endFrame, frame);
-  }
-
-  private isInRange(frame: number): boolean {
-    return frame >= this.startFrame && frame <= this.endFrame;
   }
 
   private syncAudio(frameOffset = 0) {

--- a/packages/ui/src/components/animations/borderHighlight.ts
+++ b/packages/ui/src/components/animations/borderHighlight.ts
@@ -1,0 +1,9 @@
+export function borderHighlight(): Keyframe[] {
+  return [
+    {
+      borderColor: 'var(--theme)',
+      easing: 'cubic-bezier(0.32, 0, 0.67, 0)',
+    },
+    {},
+  ];
+}

--- a/packages/ui/src/components/animations/index.ts
+++ b/packages/ui/src/components/animations/index.ts
@@ -1,3 +1,4 @@
+export * from './borderHighlight';
 export * from './emphasize';
 export * from './shake';
 export * from './highlight';

--- a/packages/ui/src/components/timeline/Label.tsx
+++ b/packages/ui/src/components/timeline/Label.tsx
@@ -30,9 +30,12 @@ export function Label({event, scene}: LabelProps) {
           }
         }}
         onPointerDown={e => {
-          e.currentTarget.setPointerCapture(e.pointerId);
-          if (e.button === 1) {
-            e.preventDefault();
+          e.preventDefault();
+          if (e.button === 0) {
+            e.stopPropagation();
+            e.currentTarget.setPointerCapture(e.pointerId);
+            labelClipDraggingLeftSignal.value = eventTime;
+          } else if (e.button === 1) {
             player.requestSeek(
               scene.firstFrame +
                 player.status.secondsToFrames(event.initialTime + event.offset),
@@ -41,19 +44,22 @@ export function Label({event, scene}: LabelProps) {
         }}
         onPointerMove={e => {
           if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.stopPropagation();
             const newTime =
               eventTime +
               player.status.framesToSeconds(pixelsToFrames(e.movementX));
-            labelClipDraggingLeftSignal.value = newTime;
+            labelClipDraggingLeftSignal.value = Math.max(0, newTime);
             setEventTime(newTime);
           }
         }}
         onPointerUp={e => {
-          e.currentTarget.releasePointerCapture(e.pointerId);
-          labelClipDraggingLeftSignal.value = null;
-          const newFrame = Math.max(0, eventTime);
-          if (event.offset !== newFrame) {
-            scene.timeEvents.set(event.name, newFrame, e.shiftKey);
+          if (e.button === 0) {
+            e.currentTarget.releasePointerCapture(e.pointerId);
+            labelClipDraggingLeftSignal.value = null;
+            const newFrame = Math.max(0, eventTime);
+            if (event.offset !== newFrame) {
+              scene.timeEvents.set(event.name, newFrame, e.shiftKey);
+            }
           }
         }}
         className={styles.labelClip}

--- a/packages/ui/src/components/timeline/RangeSelector.tsx
+++ b/packages/ui/src/components/timeline/RangeSelector.tsx
@@ -1,16 +1,16 @@
 import styles from './Timeline.module.scss';
 
-import {
-  useDrag,
-  useDuration,
-  usePreviewSettings,
-  useSharedSettings,
-} from '../../hooks';
+import {useDuration, usePreviewSettings, useSharedSettings} from '../../hooks';
 import {useCallback, useEffect, useState} from 'preact/hooks';
 import {useApplication, useTimelineContext} from '../../contexts';
 import {DragIndicator} from '../icons';
+import {RefObject} from 'preact';
 
-export function RangeSelector() {
+export interface RangeSelectorProps {
+  rangeRef: RefObject<HTMLDivElement>;
+}
+
+export function RangeSelector({rangeRef}: RangeSelectorProps) {
   const {pixelsToFrames, framesToPercents} = useTimelineContext();
 
   const {player, meta} = useApplication();
@@ -26,37 +26,6 @@ export function RangeSelector() {
     meta.shared.range.update(start, end, duration, fps);
   }, [start, end, duration, fps]);
 
-  const [handleDragStart] = useDrag(
-    useCallback(
-      dx => {
-        setStart(start + pixelsToFrames(dx));
-      },
-      [start, pixelsToFrames],
-    ),
-    onDrop,
-  );
-
-  const [handleDragEnd] = useDrag(
-    useCallback(
-      dx => {
-        setEnd(end + pixelsToFrames(dx));
-      },
-      [end, pixelsToFrames, duration],
-    ),
-    onDrop,
-  );
-
-  const [handleDrag] = useDrag(
-    useCallback(
-      dx => {
-        setStart(start + pixelsToFrames(dx));
-        setEnd(end + pixelsToFrames(dx));
-      },
-      [start, end, duration, pixelsToFrames],
-    ),
-    onDrop,
-  );
-
   useEffect(() => {
     setStart(startFrame);
     setEnd(endFrame);
@@ -71,24 +40,77 @@ export function RangeSelector() {
 
   return (
     <div
+      ref={rangeRef}
       style={{
         flexDirection: start > end ? 'row-reverse' : 'row',
         left: `${framesToPercents(Math.max(0, normalizedStart))}%`,
         right: `${100 - framesToPercents(Math.min(duration, normalizedEnd))}%`,
       }}
       className={styles.range}
-      onMouseDown={event => {
-        if (event.button === 1) {
-          event.preventDefault();
+      onPointerDown={event => {
+        event.preventDefault();
+        if (event.button === 0) {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } else if (event.button === 1) {
+          event.stopPropagation();
           meta.shared.range.update(0, Infinity, duration, fps);
-        } else {
-          handleDrag(event);
+        }
+      }}
+      onPointerMove={event => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          setStart(start + pixelsToFrames(event.movementX));
+          setEnd(end + pixelsToFrames(event.movementX));
+        }
+      }}
+      onPointerUp={event => {
+        if (event.button === 0) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+          onDrop();
         }
       }}
     >
-      <DragIndicator onMouseDown={handleDragStart} className={styles.handle} />
+      <RangeHandle
+        onDrag={event => setStart(start + pixelsToFrames(event.movementX))}
+        onDrop={onDrop}
+      />
       <div class={styles.handleSpacer} />
-      <DragIndicator onMouseDown={handleDragEnd} className={styles.handle} />
+      <RangeHandle
+        onDrag={event => setEnd(end + pixelsToFrames(event.movementX))}
+        onDrop={onDrop}
+      />
     </div>
+  );
+}
+
+interface RangeHandleProps {
+  onDrag: (event: PointerEvent) => void;
+  onDrop: (event: PointerEvent) => void;
+}
+
+function RangeHandle({onDrag, onDrop}: RangeHandleProps) {
+  return (
+    <DragIndicator
+      className={styles.handle}
+      onPointerDown={event => {
+        if (event.button === 0) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.currentTarget.setPointerCapture(event.pointerId);
+        }
+      }}
+      onPointerMove={event => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.stopPropagation();
+          onDrag(event);
+        }
+      }}
+      onPointerUp={event => {
+        if (event.button === 0) {
+          event.stopPropagation();
+          event.currentTarget.releasePointerCapture(event.pointerId);
+          onDrop(event);
+        }
+      }}
+    />
   );
 }

--- a/packages/ui/src/components/viewport/Timestamp.tsx
+++ b/packages/ui/src/components/viewport/Timestamp.tsx
@@ -6,9 +6,18 @@ import styles from './Viewport.module.scss';
 
 interface TimestampProps extends JSX.HTMLAttributes<HTMLInputElement> {
   frame: number;
+  title: string;
+  frameTitle: string;
+  reverse?: boolean;
 }
 
-export function Timestamp({frame, ...rest}: TimestampProps) {
+export function Timestamp({
+  frame,
+  reverse = false,
+  title,
+  frameTitle,
+  ...rest
+}: TimestampProps) {
   const {player} = useApplication();
   const {speed} = usePlayerState();
 
@@ -19,13 +28,20 @@ export function Timestamp({frame, ...rest}: TimestampProps) {
     padding += 3;
   }
 
+  const frames = (
+    <span title={frameTitle} className={styles.frames}>
+      [{frame.toFixed(precision)}]
+    </span>
+  );
+
   return (
     <code {...rest}>
-      <span>
+      {reverse && frames}
+      <span title={`${title} [HH:MM:SS:FF]`}>
         {formatDuration(player.status.framesToSeconds(frame))}:
         {(frame % player.status.fps).toFixed(precision).padStart(padding, '0')}
       </span>
-      <span className={styles.frames}>[{frame.toFixed(precision)}]</span>
+      {!reverse && frames}
     </code>
   );
 }

--- a/packages/ui/src/components/viewport/Viewport.tsx
+++ b/packages/ui/src/components/viewport/Viewport.tsx
@@ -37,15 +37,18 @@ function EditorViewport() {
           render={time => (
             <Timestamp
               className={styles.time}
-              title="Current Time"
+              title="Current time"
+              frameTitle="Current frame"
               frame={time}
             />
           )}
         />
         <PlaybackControls />
         <Timestamp
+          reverse
           className={styles.duration}
           title="Duration"
+          frameTitle="Duration in frames"
           frame={duration}
         />
       </div>


### PR DESCRIPTION
- Trying to seek outside the range triggers an animation to convey to users that the range is preventing them from seeking. This is a common problem for new users who sometimes edit the range by mistake and then can't figure out why their animation is not playing past a certain point (the end of the range)
- The range selector no longer uses `useDrag` in favor of pointer captures.
- Fixed the preview playhead not snapping to time events in some edge cases.
- Fixed the order of the duration timestamp - frames are now on the left.