### PR TITLE
feat(vite-plugin): support glob for project files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11732,8 +11732,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "license": "MIT",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -23137,6 +23138,7 @@
       "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
+        "fast-glob": "^3.3.1",
         "follow-redirects": "^1.15.2",
         "mime-types": "^2.1.35"
       },
@@ -26905,6 +26907,7 @@
         "@types/follow-redirects": "^1.14.1",
         "@types/mime-types": "^2.1.1",
         "@types/node": "^18.14.0",
+        "fast-glob": "^3.3.1",
         "follow-redirects": "^1.15.2",
         "mime-types": "^2.1.35"
       }
@@ -31205,7 +31208,9 @@
       "version": "3.1.3"
     },
     "fast-glob": {
-      "version": "3.2.11",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",

--- a/packages/docs/docs/getting-started/configuration.mdx
+++ b/packages/docs/docs/getting-started/configuration.mdx
@@ -25,9 +25,9 @@ export default defineConfig({
 - Type: `string | string[]`
 - Default: `./src/project.ts`
 
-The import path of the project file, relative to the configuration file. A
-project file must contain a default export with an instance of the `Project`
-class.
+The import path of the project file, relative to the configuration file. Globs
+are also supported. A project file must contain a default export with an
+instance of the `Project` class.
 
 When set to an array, the Editor will display a project selection screen, making
 it possible to change the project without restarting Vite.

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^18.14.0"
   },
   "dependencies": {
+    "fast-glob": "^3.3.1",
     "follow-redirects": "^1.15.2",
     "mime-types": "^2.1.35"
   }

--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -12,12 +12,14 @@ import {getVersions} from './versions';
 import {PluginOptions, isPlugin, PLUGIN_OPTIONS, ProjectData} from './plugins';
 import {openInExplorer} from './openInExplorer';
 import * as os from 'os';
+import fg from 'fast-glob';
 
 const AudioExtensions = new Set(['.mp3', '.wav', '.ogg', '.aac', '.flac']);
 
 export interface MotionCanvasPluginConfig {
   /**
    * The import path of the project file or an array of paths.
+   * Also supports globs.
    *
    * @remarks
    * Each file must contain a default export exposing an instance of the
@@ -117,7 +119,26 @@ export default ({
   const outputPath = path.resolve(output);
   const projects: ProjectData[] = [];
   const projectLookup: Record<string, ProjectData> = {};
-  for (const url of typeof project === 'string' ? [project] : project) {
+
+  function expandFilePaths(filePaths: string[] | string): string[] {
+    const expandedFilePaths = [];
+
+    for (const filePath of typeof filePaths === 'string'
+      ? [filePaths]
+      : filePaths) {
+      if (fg.isDynamicPattern(filePath)) {
+        const matchingFilePaths = fg.sync(filePath, {onlyFiles: true});
+        expandedFilePaths.push(...matchingFilePaths);
+      } else {
+        expandedFilePaths.push(filePath);
+      }
+    }
+
+    return expandedFilePaths;
+  }
+
+  const projectList = expandFilePaths(project);
+  for (const url of projectList) {
     const {name, dir} = path.posix.parse(url);
     const metaFile = `${name}.meta`;
     const metaData = getMeta(path.join(dir, metaFile));


### PR DESCRIPTION
Adopting the stale pull request #576 because it failed CI.

Support glob patterns for project files in the vite-plugin.

Please credit @guifeliper as below if squash-merging.

Closes: #324
Co-Authored-By: Guilherme Reis <guifeliper@gmail.com>