### PR TITLE
refactor(ui): collapse render buttons

### DIFF
--- a/packages/ui/src/components/sidebar/VideoSettings.tsx
+++ b/packages/ui/src/components/sidebar/VideoSettings.tsx
@@ -1,5 +1,5 @@
 import {useRendererState, useStorage} from '../../hooks';
-import {Button, ButtonSelect, Group, Label} from '../controls';
+import {Button, ButtonSelect, Group, Label, Separator} from '../controls';
 import {Pane} from '../tabs';
 import {useApplication} from '../../contexts';
 import {Expandable} from '../fields';
@@ -16,27 +16,28 @@ export function VideoSettings() {
       <Expandable title={meta.shared.name} open>
         <MetaFieldView field={meta.shared} />
       </Expandable>
-      <Expandable title={meta.preview.name}>
+      <Expandable title={meta.preview.name} open>
         <MetaFieldView field={meta.preview} />
       </Expandable>
-      <Expandable title={meta.rendering.name}>
+      <Expandable title={meta.rendering.name} open>
         <MetaFieldView field={meta.rendering} />
-      </Expandable>
-      <Group>
-        <Label />
-        <ProcessButton processId={processId} setProcess={setProcess} />
-      </Group>
-      {processId === 0 && (
+        <Separator />
         <Group>
           <Label />
-          <Button
-            title="Reveal the output directory in file explorer"
-            onClick={openOutputPath}
-          >
-            Output Directory
-          </Button>
+          <ProcessButton processId={processId} setProcess={setProcess} />
         </Group>
-      )}
+        {processId === 0 && (
+          <Group>
+            <Label />
+            <Button
+              title="Reveal the output directory in file explorer"
+              onClick={openOutputPath}
+            >
+              Output Directory
+            </Button>
+          </Group>
+        )}
+      </Expandable>
     </Pane>
   );
 }


### PR DESCRIPTION
Buttons related to rendering are now contained in the same collapsable as the rendering settings. This is meant to prevent people from mistakenly assuming that the rendering options are expanded when they are not.