### PR TITLE
feat(core & ui): add audio volume control through arrow keys

### DIFF
--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -18,6 +18,7 @@ export interface PlayerState extends Record<string, unknown> {
   paused: boolean;
   loop: boolean;
   muted: boolean;
+  volume: number;
   speed: number;
 }
 
@@ -127,6 +128,7 @@ export class Player {
     this.playerState = new ValueDispatcher<PlayerState>({
       loop: true,
       muted: true,
+      volume: 1,
       speed: 1,
       ...initialState,
       paused: true,
@@ -278,6 +280,25 @@ export class Player {
     }
   }
 
+  public setAudioVolume(value: number): void {
+    if (value !== this.playerState.current.volume) {
+      this.playerState.current = {
+        ...this.playerState.current,
+        volume: value,
+      };
+    }
+  }
+
+  public addAudioVolume(value: number): void {
+    const newValue = clamp(0, 1, this.playerState.current.volume + value);
+    if (newValue !== this.playerState.current.volume) {
+      this.playerState.current = {
+        ...this.playerState.current,
+        volume: newValue,
+      };
+    }
+  }
+
   public setSpeed(value: number) {
     if (value !== this.playerState.current.speed) {
       this.playback.speed = value;
@@ -383,6 +404,7 @@ export class Player {
       this.syncAudio(-3);
     }
     this.audio.setMuted(state.muted);
+    this.audio.setVolume(state.volume);
 
     return state;
   }

--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -281,22 +281,17 @@ export class Player {
   }
 
   public setAudioVolume(value: number): void {
-    if (value !== this.playerState.current.volume) {
+    const clampedValue = clamp(0, 1, value);
+    if (clampedValue !== this.playerState.current.volume) {
       this.playerState.current = {
         ...this.playerState.current,
-        volume: value,
+        volume: clampedValue,
       };
     }
   }
 
   public addAudioVolume(value: number): void {
-    const newValue = clamp(0, 1, this.playerState.current.volume + value);
-    if (newValue !== this.playerState.current.volume) {
-      this.playerState.current = {
-        ...this.playerState.current,
-        volume: newValue,
-      };
-    }
+    this.setAudioVolume(this.playerState.current.volume + value);
   }
 
   public setSpeed(value: number) {

--- a/packages/core/src/media/AudioManager.ts
+++ b/packages/core/src/media/AudioManager.ts
@@ -41,6 +41,10 @@ export class AudioManager {
     this.audioElement.muted = isMuted;
   }
 
+  public setVolume(volume: number) {
+    this.audioElement.volume = volume;
+  }
+
   public setSource(src: string) {
     this.source = src;
     this.audioElement.src = src;

--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -55,6 +55,12 @@ export function PlaybackControls() {
           case 'm':
             player.toggleAudio();
             break;
+          case 'ArrowUp':
+            player.addAudioVolume(0.1);
+            break;
+          case 'ArrowDown':
+            player.addAudioVolume(-0.1);
+            break;
           case 'l':
             player.toggleLoop();
             break;


### PR DESCRIPTION
Adds the ability to control the volume of audio through arrow keys (up and down). This will update the volume by 10% increments.

Solves #320 partially.

There's no visible UI element yet since I think some discussion on how that should look like before implementing would be good. 
However, this will at least give people the option to control the volume if they know the button to press.