### PR TITLE
feat: better children and spawners

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,12 @@
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-namespace": "off",
     "tsdoc/syntax": "error",
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "ignoreRestSiblings": true
+      }
+    ],
     "@typescript-eslint/naming-convention": [
       "error",
       {

--- a/packages/2d/src/components/__tests__/children.test.tsx
+++ b/packages/2d/src/components/__tests__/children.test.tsx
@@ -1,0 +1,142 @@
+import {describe, it, expect} from 'vitest';
+import {createRef, createSignal, range} from '@motion-canvas/core';
+import {mockScene2D} from './mockScene2D';
+import {useScene2D} from '../../scenes';
+import {Node} from '../Node';
+
+describe('children', () => {
+  mockScene2D();
+
+  it('Append children', () => {
+    const view = useScene2D().getView();
+    const parent = createRef<Node>();
+    const childA = createRef<Node>();
+    const childB = createRef<Node>();
+
+    view.add(
+      <Node ref={parent}>
+        <Node ref={childA} />
+        <Node ref={childB} />
+      </Node>,
+    );
+
+    expect(childA().parent()).toBe(parent());
+    expect(childB().parent()).toBe(parent());
+    expect(parent().children()).toEqual([childA(), childB()]);
+  });
+
+  it('Clear children', () => {
+    const view = useScene2D().getView();
+    const parent = createRef<Node>();
+    const childA = createRef<Node>();
+    const childB = createRef<Node>();
+
+    view.add(
+      <Node ref={parent}>
+        <Node ref={childA} />
+        <Node ref={childB} />
+      </Node>,
+    );
+
+    parent().removeChildren();
+
+    expect(childA().parent()).toBe(null);
+    expect(childB().parent()).toBe(null);
+    expect(parent().children()).toEqual([]);
+  });
+
+  it('Replace children', () => {
+    const view = useScene2D().getView();
+    const parent = createRef<Node>();
+    const childA = <Node />;
+    const childB = <Node />;
+
+    view.add(<Node ref={parent}>{childA}</Node>);
+
+    parent().children(childB);
+
+    expect(childA.parent()).toBe(null);
+    expect(childB.parent()).toBe(parent());
+    expect(parent().children()).toEqual([childB]);
+  });
+
+  it('Take a child from another node', () => {
+    const view = useScene2D().getView();
+    const parentA = createRef<Node>();
+    const parentB = createRef<Node>();
+    const child = createRef<Node>();
+
+    view.add(
+      <>
+        <Node ref={parentA}>
+          <Node ref={child} />
+        </Node>
+        <Node ref={parentB} />
+      </>,
+    );
+
+    expect(parentA().children()).toEqual([child()]);
+    expect(parentB().children()).toEqual([]);
+    expect(child().parent()).toBe(parentA());
+
+    parentB().children(child());
+
+    expect(parentA().children()).toEqual([]);
+    expect(parentB().children()).toEqual([child()]);
+    expect(child().parent()).toBe(parentB());
+  });
+
+  it('Append children conditionally', () => {
+    const view = useScene2D().getView();
+    const parent = createRef<Node>();
+    const childA = <Node />;
+    const childB = <Node />;
+    const predicate = createSignal(false);
+
+    view.add(<Node ref={parent}>{() => (predicate() ? childA : childB)}</Node>);
+
+    expect(parent().children()).toEqual([childB]);
+    expect(childA.parent()).toBe(null);
+    expect(childB.parent()).toBe(parent());
+
+    predicate(true);
+
+    expect(parent().children()).toEqual([childA]);
+    expect(childA.parent()).toBe(parent());
+    expect(childB.parent()).toBe(null);
+  });
+
+  it('Spawn reactive children', () => {
+    const view = useScene2D().getView();
+    const parent = createRef<Node>();
+    const count = createSignal(3);
+
+    view.add(
+      <Node ref={parent}>{() => range(count()).map(() => <Node />)}</Node>,
+    );
+
+    expect(parent().children().length).toBe(3);
+
+    count(5);
+
+    expect(parent().children().length).toBe(5);
+  });
+
+  it('Replace a spawner', () => {
+    const view = useScene2D().getView();
+    const parent = createRef<Node>();
+    const childA = <Node />;
+    const childB = <Node />;
+
+    view.add(<Node ref={parent}>{() => childA}</Node>);
+
+    expect(parent().children()).toEqual([childA]);
+    expect(childA.parent()).toBe(parent());
+
+    parent().children(childB);
+
+    expect(childA.parent()).toBe(null);
+    expect(childB.parent()).toBe(parent());
+    expect(parent().children()).toEqual([childB]);
+  });
+});

--- a/packages/2d/src/scenes/Scene2D.ts
+++ b/packages/2d/src/scenes/Scene2D.ts
@@ -13,7 +13,7 @@ import {Node, View2D} from '../components';
 
 export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
   private view: View2D | null = null;
-  private readonly registeredNodes = new Map<string, Node>();
+  private registeredNodes = new Map<string, Node>();
   private readonly nodeCounters = new Map<string, number>();
   private assetHash = Date.now().toString();
 
@@ -61,6 +61,7 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
       }
     }
     this.registeredNodes.clear();
+    this.registeredNodes = new Map<string, Node>();
     this.nodeCounters.clear();
     this.recreateView();
 
@@ -123,7 +124,7 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
       .transformAsPoint(this.getView().localToParent().inverse());
   }
 
-  public registerNode(node: Node, key?: string): string {
+  public registerNode(node: Node, key?: string): [string, () => void] {
     const className = node.constructor?.name ?? 'unknown';
     const counter = (this.nodeCounters.get(className) ?? 0) + 1;
     this.nodeCounters.set(className, counter);
@@ -139,7 +140,8 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
 
     key ??= `${this.name}/${className}[${counter}]`;
     this.registeredNodes.set(key, node);
-    return key;
+    const currentNodeMap = this.registeredNodes;
+    return [key, () => currentNodeMap.delete(key!)];
   }
 
   public getNode(key: any): Node | null {

--- a/packages/docs/docs/advanced/spawners.mdx
+++ b/packages/docs/docs/advanced/spawners.mdx
@@ -15,7 +15,7 @@ const count = createSignal(10);
 view.add(
   <Layout layout>
     {range(count()).map(() => (
-      <Circle width={32} height={32} fill={'white'} />
+      <Circle size={32} fill={'white'} />
     ))}
   </Layout>,
 );
@@ -25,36 +25,46 @@ We first create the `count` signal and then use its value to generate N number
 of circles.
 
 This example is not reactive - changing the `count` signal won't change the
-number of circles inside the `Layout` node. We can fix that with the use of the
-[`spawner`](/api/2d/components/NodeProps#spawner) property:
+number of circles inside the `Layout` node. We can fix that by using a function
+that returns the children instead of writing them directly:
 
 ```tsx
 const count = createSignal(10);
 
 view.add(
-  <Layout
-    layout
-    spawner={() =>
-      range(count()).map(() => <Circle width={32} height={32} fill={'white'} />)
-    }
-  />,
+  <Layout layout>
+    {() => range(count()).map(() => <Circle size={32} fill={'white'} />)}
+  </Layout>,
 );
 ```
 
-`spawner` accepts a function that returns an array of nodes. These nodes will
-become the new children of the `Layout` node. We can now animate our `count`
-signal to check if it works:
+Throughout this guide, we will refer to functions that return children as
+**spawners**. Like any other signal, this function will keep track of its
+dependencies and recompute its value whenever they change. We can animate our
+`count` signal to see if it works:
 
-```ts
-yield * count(5, 2);
+```tsx editor
+import {makeScene2D, Layout, Circle} from '@motion-canvas/2d';
+import {createSignal, linear, range} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const count = createSignal(10);
+
+  view.add(
+    <Layout layout>
+      {() => range(count()).map(() => <Circle size={32} fill={'white'} />)}
+    </Layout>,
+  );
+
+  yield* count(3, 2, linear).wait(1).back(2);
+});
 ```
 
-It's important to remember that (like most Node properties) `spawner` is a
-signal. The function we pass to it will be invoked each time any of its
-dependencies change. If the spawner happens to generate a large number of nodes
-and its dependencies change every frame, it may drastically reduce the
-playback's performance. To counteract this, we can use an object pool that will
-let us reuse the same nodes instead of recreating them each time:
+It's important to remember that creating new nodes comes with some overhead. If
+our spawner happens to generate a large number of nodes and its dependencies
+change every frame, it may drastically reduce the playback's performance. To
+counteract this, we can use an object pool that will let us reuse the same nodes
+instead of recreating them each time:
 
 ```tsx
 const count = createSignal(10);
@@ -64,22 +74,21 @@ const pool = range(64).map(i => (
 ));
 
 const layout = createRef<Layout>();
-view.add(<Layout layout ref={layout} spawner={() => pool.slice(0, count())} />);
+view.add(
+  <Layout layout ref={layout}>
+    {() => pool.slice(0, count())}
+  </Layout>,
+);
 ```
 
 Apart from the spawner function, the pool should never be accessed directly. Use
-the `children()` signal of the parent object to get references to the spawned
-objects:
+the helper methods on the parent object to get references to the spawned
+children:
 
 ```tsx
 // ... continuing from above ...
-let spawnedCircles = layout().children() as Circle[];
-yield *
-  all(
-    ...spawnedCircles.map(function* (circle) {
-      yield* circle.scale(1.5, 1).to(1, 1);
-    }),
-  );
+let spawnedCircles = layout().childrenAs<Circle>();
+yield * all(...spawnedCircles.map(circle => circle.scale(1.5, 1).to(1, 1)));
 ```
 
 Be aware that the references returned by a call to `children()` may be


### PR DESCRIPTION
Deprecates `spawner` in favor of `children`.
Reactivity can still be achieved by passing a function as the `children` property:
```tsx
view.add(
  <Node>{() => range(count()).map(() => <Node />)}</Node>,
);
```

The property itself is now smarter and will automatically maintain the integrity of the tree.
For example, the following now works perfectly fine:
```tsx
const parentA = createRef<Node>();
const parentB = createRef<Node>();
const child = createRef<Node>();

view.add(
  <>
    <Node ref={parentA}>
      <Node ref={child} />
    </Node>
    <Node ref={parentB} />
  </>,
);

// Steal child from parentA and move it to parentB
parentB().children(child());
// The child is automatically removed from parentA:
// parentA().children() == []
```
