### PR TITLE
feat(ui): timeline scrubbing

### DIFF
--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -496,7 +496,7 @@ export class Player {
     });
   }
 
-  private clampRange(frame: number): number {
+  public clampRange(frame: number): number {
     return clamp(this.startFrame, this.endFrame, frame);
   }
 

--- a/packages/ui/src/components/timeline/Playhead.tsx
+++ b/packages/ui/src/components/timeline/Playhead.tsx
@@ -2,17 +2,24 @@ import styles from './Timeline.module.scss';
 
 import {usePlayerState, usePlayerTime} from '../../hooks';
 import {useTimelineContext} from '../../contexts';
+import {Signal} from '@preact/signals';
 
-export function Playhead() {
+interface PlayheadProps {
+  seeking: Signal<number | null>;
+}
+
+export function Playhead({seeking}: PlayheadProps) {
   const {framesToPixels} = useTimelineContext();
   const {speed} = usePlayerState();
   const time = usePlayerTime();
+  const frame = seeking.value ?? time.frame;
+
   return (
     <div
       className={styles.playhead}
-      data-frame={formatFrames(time.frame, speed)}
+      data-frame={formatFrames(frame, speed)}
       style={{
-        left: `${framesToPixels(time.frame)}px`,
+        left: `${framesToPixels(frame)}px`,
       }}
     />
   );

--- a/packages/ui/src/components/timeline/Timeline.module.scss
+++ b/packages/ui/src/components/timeline/Timeline.module.scss
@@ -293,6 +293,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
+
+  &.active {
+    pointer-events: auto;
+    border-color: rgba(255, 255, 255, 0.24);
+  }
 }
 
 .handle {
@@ -300,7 +306,7 @@
   margin-top: 2px;
   color: rgba(255, 255, 255, 0);
 
-  .range:hover > & {
+  .range.active > & {
     color: rgba(255, 255, 255, 0.24);
     z-index: 1;
     min-width: 24px;
@@ -323,13 +329,16 @@
   margin: 24px 0;
   opacity: 0;
   transition: opacity var(--duration-normal);
+  pointer-events: none;
+  filter: brightness(0.27);
 
   &.show {
     opacity: 1;
   }
 
   &.active {
+    pointer-events: auto;
     cursor: move;
-    filter: brightness(0.9);
+    filter: brightness(0.32);
   }
 }

--- a/packages/ui/src/hooks/useHover.ts
+++ b/packages/ui/src/hooks/useHover.ts
@@ -24,12 +24,12 @@ export function useHover<T extends HTMLElement>(
     () => {
       const node = ref.current;
       if (node) {
-        node.addEventListener('mouseover', handleMouseOverWrapper);
-        node.addEventListener('mouseout', handleMouseOutWrapper);
+        node.addEventListener('mouseenter', handleMouseOverWrapper);
+        node.addEventListener('mouseleave', handleMouseOutWrapper);
 
         return () => {
-          node.removeEventListener('mouseover', handleMouseOverWrapper);
-          node.removeEventListener('mouseout', handleMouseOutWrapper);
+          node.removeEventListener('mouseenter', handleMouseOverWrapper);
+          node.removeEventListener('mouseleave', handleMouseOutWrapper);
         };
       }
     },

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './clamp';
 export * from './compareVersions';
 export * from './formatDuration';
 export * from './localStorage';
+export * from './mouse';
 export * from './openOutputPath';
 export * from './sourceMaps';
 export * from './withLoader';

--- a/packages/ui/src/utils/mouse.ts
+++ b/packages/ui/src/utils/mouse.ts
@@ -1,0 +1,14 @@
+export enum MouseButton {
+  Left = 0,
+  Middle = 1,
+  Right = 2,
+}
+
+export enum MouseMask {
+  None = 0,
+  Primary = 1,
+  Secondary = 2,
+  Auxiliary = 4,
+  Back = 8,
+  Forward = 16,
+}


### PR DESCRIPTION
Makes it possible to scrub the timeline (pressing LMB while dragging left and right)
The range is no longer editable by default. Like the audio track, it requires `SHIFT` to be held down in order to be edited.

Closes: #286