### PR TITLE
feat(ui): add volume slider

### DIFF
--- a/packages/ui/src/components/controls/Controls.module.scss
+++ b/packages/ui/src/components/controls/Controls.module.scss
@@ -286,3 +286,36 @@
     }
   }
 }
+
+.slider {
+  display: flex;
+  justify-content: center;
+  height: 120px;
+  width: 24px;
+  cursor: pointer;
+}
+
+.sliderTrack {
+  position: relative;
+  width: 4px;
+  border-radius: var(--radius);
+  background-color: var(--background-color-dark);
+}
+
+.sliderProgress {
+  position: absolute;
+  bottom: 0;
+  width: 4px;
+  border-radius: var(--radius);
+  background-color: var(--theme);
+}
+
+.sliderThumb {
+  position: absolute;
+  left: -4px;
+  bottom: calc(100% - 2px);
+  width: 12px;
+  height: 4px;
+  border-radius: var(--radius);
+  background-color: var(--theme);
+}

--- a/packages/ui/src/components/controls/Controls.module.scss
+++ b/packages/ui/src/components/controls/Controls.module.scss
@@ -297,25 +297,24 @@
 
 .sliderTrack {
   position: relative;
-  width: 4px;
+  display: flex;
+  align-items: end;
+  width: 2px;
   border-radius: var(--radius);
   background-color: var(--background-color-dark);
 }
 
 .sliderProgress {
-  position: absolute;
-  bottom: 0;
-  width: 4px;
+  width: 2px;
   border-radius: var(--radius);
   background-color: var(--theme);
 }
 
 .sliderThumb {
-  position: absolute;
-  left: -4px;
-  bottom: calc(100% - 2px);
-  width: 12px;
-  height: 4px;
-  border-radius: var(--radius);
+  width: 8px;
+  height: 8px;
+  margin-left: -3px;
+  margin-top: -4px;
+  border-radius: 4px;
   background-color: var(--theme);
 }

--- a/packages/ui/src/components/controls/Slider.tsx
+++ b/packages/ui/src/components/controls/Slider.tsx
@@ -1,0 +1,63 @@
+import {useEffect, useState} from 'preact/hooks';
+import {MouseButton, clamp} from '../../utils';
+import styles from './Controls.module.scss';
+
+export interface SliderProps {
+  value?: number;
+  onChange?: (value: number) => void;
+}
+
+export function Slider({value, onChange}: SliderProps) {
+  const [internalValue, setInternalValue] = useState(value);
+
+  useEffect(() => {
+    setInternalValue(value);
+  }, [value]);
+
+  return (
+    <div
+      className={styles.slider}
+      onPointerDown={event => {
+        if (event.button === MouseButton.Left) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.currentTarget.setPointerCapture(event.pointerId);
+
+          const rect = event.currentTarget.getBoundingClientRect();
+          // +2 & +4 to account for thumb offset
+          const y = event.clientY - rect.y + 2;
+          const newInternalValue = 1 - y / (rect.height + 4);
+          setInternalValue(clamp(0, 1, newInternalValue));
+        }
+      }}
+      onPointerMove={event => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.stopPropagation();
+
+          const rect = event.currentTarget.getBoundingClientRect();
+          // +2 & +4 to account for thumb offset
+          const y = event.clientY - rect.y + 2;
+          const newInternalValue = 1 - y / (rect.height + 4);
+          setInternalValue(clamp(0, 1, newInternalValue));
+        }
+      }}
+      onPointerUp={event => {
+        if (event.button === MouseButton.Left) {
+          event.stopPropagation();
+          event.currentTarget.releasePointerCapture(event.pointerId);
+
+          onChange?.(internalValue);
+        }
+      }}
+    >
+      <div className={styles.sliderTrack}>
+        <div
+          className={styles.sliderProgress}
+          style={`height: ${internalValue * 100}%`}
+        >
+          <div className={styles.sliderThumb} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/controls/Slider.tsx
+++ b/packages/ui/src/components/controls/Slider.tsx
@@ -24,9 +24,8 @@ export function Slider({value, onChange}: SliderProps) {
           event.currentTarget.setPointerCapture(event.pointerId);
 
           const rect = event.currentTarget.getBoundingClientRect();
-          // +2 & +4 to account for thumb offset
-          const y = event.clientY - rect.y + 2;
-          const newInternalValue = 1 - y / (rect.height + 4);
+          const y = clamp(0, rect.height, event.clientY - rect.y);
+          const newInternalValue = 1 - y / rect.height;
           setInternalValue(clamp(0, 1, newInternalValue));
         }
       }}
@@ -35,9 +34,8 @@ export function Slider({value, onChange}: SliderProps) {
           event.stopPropagation();
 
           const rect = event.currentTarget.getBoundingClientRect();
-          // +2 & +4 to account for thumb offset
-          const y = event.clientY - rect.y + 2;
-          const newInternalValue = 1 - y / (rect.height + 4);
+          const y = clamp(0, rect.height, event.clientY - rect.y);
+          const newInternalValue = 1 - y / rect.height;
           setInternalValue(clamp(0, 1, newInternalValue));
         }
       }}

--- a/packages/ui/src/components/controls/index.ts
+++ b/packages/ui/src/components/controls/index.ts
@@ -11,4 +11,5 @@ export * from './Label';
 export * from './Pill';
 export * from './Select';
 export * from './Separator';
+export * from './Slider';
 export * from './Toggle';

--- a/packages/ui/src/components/playback/Playback.module.scss
+++ b/packages/ui/src/components/playback/Playback.module.scss
@@ -26,25 +26,16 @@
 .volumeMargin {
   position: absolute;
   bottom: 24px;
-  left: -12px;
-  width: 48px;
-  height: 180px;
+  left: 0;
+  right: 0;
+  padding-bottom: 18px;
   display: none;
 }
-
 .volume {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 24px;
-  height: 144px;
+  padding: 12px 0;
   border-radius: var(--radius);
   background-color: var(--surface-color);
 }
-
 .volumeTrigger:hover .volumeMargin {
-  display: grid;
+  display: block;
 }

--- a/packages/ui/src/components/playback/Playback.module.scss
+++ b/packages/ui/src/components/playback/Playback.module.scss
@@ -18,3 +18,33 @@
     width: 100px;
   }
 }
+
+.volumeTrigger {
+  position: relative;
+}
+
+.volumeMargin {
+  position: absolute;
+  bottom: 24px;
+  left: -12px;
+  width: 48px;
+  height: 180px;
+  display: none;
+}
+
+.volume {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 144px;
+  border-radius: var(--radius);
+  background-color: var(--surface-color);
+}
+
+.volumeTrigger:hover .volumeMargin {
+  display: grid;
+}

--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -3,7 +3,7 @@ import styles from './Playback.module.scss';
 import {useCallback} from 'preact/hooks';
 import {useApplication} from '../../contexts';
 import {useDocumentEvent, usePlayerState} from '../../hooks';
-import {IconButton, IconCheckbox, Input, Select} from '../controls';
+import {IconButton, IconCheckbox, Input, Select, Slider} from '../controls';
 import {
   FastForward,
   FastRewind,
@@ -84,14 +84,32 @@ export function PlaybackControls() {
         value={state.speed}
         onChange={speed => player.setSpeed(speed)}
       />
-      <IconCheckbox
-        titleOn="Mute audio [M]"
-        titleOff="Unmute audio [M]"
-        checked={!state.muted}
-        onChange={value => player.toggleAudio(value)}
-      >
-        {state.muted ? <VolumeOff /> : <VolumeOn />}
-      </IconCheckbox>
+      <div className={styles.volumeTrigger}>
+        <IconCheckbox
+          titleOn="Mute audio [M]"
+          titleOff="Unmute audio [M]"
+          checked={!state.muted}
+          onChange={value => player.toggleAudio(value)}
+        >
+          {state.muted ? <VolumeOff /> : <VolumeOn />}
+        </IconCheckbox>
+
+        {!state.muted && (
+          <div className={styles.volumeMargin}>
+            <div className={styles.volume}>
+              <Slider
+                value={state.volume}
+                onChange={volume => {
+                  if (isNaN(volume)) {
+                    volume = 0;
+                  }
+                  player.setAudioVolume(volume);
+                }}
+              ></Slider>
+            </div>
+          </div>
+        )}
+      </div>
       <IconButton
         title="Start [Shift + Left arrow]"
         onClick={() => player.requestReset()}

--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -105,7 +105,7 @@ export function PlaybackControls() {
                   }
                   player.setAudioVolume(volume);
                 }}
-              ></Slider>
+              />
             </div>
           </div>
         )}


### PR DESCRIPTION
Add a volume slider to adjust audio volume in addition to the existing key controls. The slider appears when hovering the sound icon, as described in #856

I had some trouble getting the default `<input type="range"/>` to look consistent accross different browsers, especially with the vertical orientation, so I build a slider component from scratch.

Closes #320 