### PR TITLE
fix(2d): supress src-Warnings in Icon- and Latex-Component when correctly using component

### DIFF
--- a/packages/2d/src/lib/components/Icon.ts
+++ b/packages/2d/src/lib/components/Icon.ts
@@ -54,17 +54,11 @@ export class Icon extends Img {
   @colorSignal()
   public declare color: ColorSignal<this>;
 
-  /**
-   * The init check is only used to supress an error warning about setting the `src` Property.
-   */
-  private init = false;
-
   public constructor(props: IconProps) {
     super({
       ...props,
-      src: null!,
+      src: null,
     });
-    this.init = true;
   }
 
   /**
@@ -90,8 +84,8 @@ export class Icon extends Img {
    * overrides `Image.src` setter to warn the user that the value
    * is not used
    */
-  protected setSrc() {
-    if (!this.init) {
+  protected setSrc(src: string | null) {
+    if (src === null) {
       return;
     }
     useLogger().warn(

--- a/packages/2d/src/lib/components/Icon.ts
+++ b/packages/2d/src/lib/components/Icon.ts
@@ -54,8 +54,17 @@ export class Icon extends Img {
   @colorSignal()
   public declare color: ColorSignal<this>;
 
+  /**
+   * The init check is only used to supress an error warning about setting the `src` Property.
+   */
+  private init = false;
+
   public constructor(props: IconProps) {
-    super(props);
+    super({
+      ...props,
+      src: null!,
+    });
+    this.init = true;
   }
 
   /**
@@ -82,6 +91,9 @@ export class Icon extends Img {
    * is not used
    */
   protected setSrc() {
+    if (!this.init) {
+      return;
+    }
     useLogger().warn(
       "The Icon Component does not accept setting the `src`. If you need access to `src`, use '<Img/>` instead.",
     );

--- a/packages/2d/src/lib/components/Img.ts
+++ b/packages/2d/src/lib/components/Img.ts
@@ -21,7 +21,7 @@ export interface ImgProps extends RectProps {
   /**
    * {@inheritDoc Img.src}
    */
-  src?: SignalValue<string>;
+  src?: SignalValue<string | null>;
   /**
    * {@inheritDoc Img.alpha}
    */

--- a/packages/2d/src/lib/components/Latex.ts
+++ b/packages/2d/src/lib/components/Latex.ts
@@ -60,7 +60,7 @@ export class Latex extends Img {
   public declare readonly tex: SimpleSignal<string, this>;
 
   public constructor(props: LatexProps) {
-    super(props);
+    super({...props, src: null});
   }
 
   protected override image(): HTMLImageElement {


### PR DESCRIPTION
This is a bugfix that prevents wrong / confusing Warn-Messages for the Icon Component.

The Icon component does not set the `src` Signal explicitly. It overrides the `src`'s getter by defining a  `getSrc` function. 

Because it doesn't set the Signal, a Warning is emitted by the parent `Img`-Class. 

This PR explicitly sets the `src` to `null` to supress the warning.

The `Icon` component also overrides the `setSrc` to tell the User that it is not supported to explicitly set the src.

In the PR, this Warning Message gets supressed until the component is fully initialized. Otherwise setting the `src` to 'null` in the constructor would also trigger that Warning.

Edit: [Additional context from Discord](https://discord.com/channels/1071029581009657896/1073222950028845138/1191273234235134144)

Edit2: Scope has been widened to also fix the `Latex` component. [See Discord](https://discord.com/channels/1071029581009657896/1071067015881707670/1191937738639949985)
