### PR TITLE
feat(ui): add direct range selection & playhead shortcuts

### DIFF
--- a/packages/ui/src/components/timeline/RangeSelector.tsx
+++ b/packages/ui/src/components/timeline/RangeSelector.tsx
@@ -9,7 +9,6 @@ import {
   useKeyHold,
   usePreviewSettings,
   useSharedSettings,
-  useSize,
 } from '../../hooks';
 import {labelClipDraggingLeftSignal} from '../../signals';
 import {MouseButton} from '../../utils';
@@ -20,8 +19,8 @@ export interface RangeSelectorProps {
 }
 
 export function RangeSelector({rangeRef}: RangeSelectorProps) {
-  const {pixelsToFrames, framesToPercents} = useTimelineContext();
-
+  const {pixelsToFrames, framesToPercents, pointerToFrames} =
+    useTimelineContext();
   const {player, meta} = useApplication();
   const {range} = useSharedSettings();
   const {fps} = usePreviewSettings();
@@ -30,7 +29,6 @@ export function RangeSelector({rangeRef}: RangeSelectorProps) {
   const endFrame = Math.min(player.status.secondsToFrames(range[1]), duration);
   const [start, setStart] = useState(startFrame);
   const [end, setEnd] = useState(endFrame);
-  const rect = useSize(rangeRef);
   const shiftHeld = useKeyHold('Shift');
   const controlHeld = useKeyHold('Control');
 
@@ -55,7 +53,7 @@ export function RangeSelector({rangeRef}: RangeSelectorProps) {
     <div
       ref={rangeRef}
       className={clsx(
-        styles.rangeContainer,
+        styles.rangeTrack,
         shiftHeld && controlHeld && styles.active,
       )}
       onPointerDown={event => {
@@ -64,8 +62,8 @@ export function RangeSelector({rangeRef}: RangeSelectorProps) {
           event.stopPropagation();
           event.currentTarget.setPointerCapture(event.pointerId);
 
-          setStart(pixelsToFrames(event.clientX - rect.x));
-          setEnd(pixelsToFrames(event.clientX - rect.x));
+          setStart(pointerToFrames(event.clientX));
+          setEnd(pointerToFrames(event.clientX));
         }
       }}
       onPointerMove={event => {

--- a/packages/ui/src/components/timeline/Timeline.module.scss
+++ b/packages/ui/src/components/timeline/Timeline.module.scss
@@ -275,8 +275,9 @@
   }
 }
 
-.rangeContainer {
+.rangeTrack {
   height: 32px;
+  cursor: pointer;
   pointer-events: none;
 
   &.active {
@@ -298,6 +299,10 @@
 
   &.active {
     pointer-events: auto;
+    border-color: rgba(255, 255, 255, 0.24);
+  }
+
+  .rangeTrack.active > & {
     border-color: rgba(255, 255, 255, 0.24);
   }
 }

--- a/packages/ui/src/components/timeline/Timeline.module.scss
+++ b/packages/ui/src/components/timeline/Timeline.module.scss
@@ -45,14 +45,6 @@
   width: 100%;
   height: 100%;
   background-color: var(--surface-color);
-
-  &::before {
-    width: 100%;
-    height: 32px;
-    display: block;
-    content: '';
-    background-color: var(--background-color);
-  }
 }
 
 .timestamp {
@@ -280,6 +272,15 @@
 
   .root:hover & {
     opacity: 0.16;
+  }
+}
+
+.rangeContainer {
+  height: 32px;
+  pointer-events: none;
+
+  &.active {
+    pointer-events: auto;
   }
 }
 

--- a/packages/ui/src/components/timeline/Timeline.tsx
+++ b/packages/ui/src/components/timeline/Timeline.tsx
@@ -2,7 +2,7 @@ import styles from './Timeline.module.scss';
 
 import {useSignal, useSignalEffect} from '@preact/signals';
 import clsx from 'clsx';
-import {useCallback, useLayoutEffect, useMemo, useRef} from 'preact/hooks';
+import {useLayoutEffect, useMemo, useRef} from 'preact/hooks';
 import {
   TimelineContextProvider,
   TimelineState,
@@ -13,6 +13,7 @@ import {
   useDuration,
   usePreviewSettings,
   useReducedMotion,
+  useSharedSettings,
   useSize,
   useStateChange,
   useStorage,
@@ -35,7 +36,8 @@ const MAX_FRAME_SIZE = 128;
 
 export function Timeline() {
   const [hoverRef] = useShortcut<HTMLDivElement>('timeline');
-  const {player} = useApplication();
+  const {player, meta} = useApplication();
+  const {range} = useSharedSettings();
   const containerRef = useRef<HTMLDivElement>();
   const playheadRef = useRef<HTMLDivElement>();
   const rangeRef = useRef<HTMLDivElement>();
@@ -123,24 +125,33 @@ export function Timeline() {
     [duration / fps, rect.width],
   );
 
-  useDocumentEvent(
-    'keydown',
-    useCallback(
-      event => {
-        if (document.activeElement.tagName === 'INPUT') {
-          return;
-        }
-        if (event.key !== 'f') return;
-        const frame = player.onFrameChanged.current;
+  useDocumentEvent('keydown', event => {
+    if (document.activeElement.tagName === 'INPUT') {
+      return;
+    }
+
+    const frame = player.onFrameChanged.current;
+    switch (event.key) {
+      case 'f': {
         const maxOffset = sizes.fullLength - sizes.viewLength;
         const scrollLeft = state.framesToPixels(frame);
         const newOffset = clamp(0, maxOffset, scrollLeft);
         containerRef.current.scrollLeft = newOffset;
         setOffset(newOffset);
-      },
-      [sizes],
-    ),
-  );
+        break;
+      }
+      case 'b': {
+        const end = player.status.secondsToFrames(range[1]);
+        meta.shared.range.update(frame, end, duration, fps);
+        break;
+      }
+      case 'n': {
+        const start = player.status.secondsToFrames(range[0]);
+        meta.shared.range.update(start, frame, duration, fps);
+        break;
+      }
+    }
+  });
 
   useLayoutEffect(() => {
     containerRef.current.scrollLeft = offset;

--- a/packages/ui/src/components/timeline/Timeline.tsx
+++ b/packages/ui/src/components/timeline/Timeline.tsx
@@ -96,6 +96,7 @@ export function Timeline() {
           relativeOffset + sizes.viewLength + TIMESTAMP_SPACING,
         ) / clampedSegmentDensity,
       ) * clampedSegmentDensity;
+    const startPosition = sizes.paddingLeft + rect.x - offset;
 
     return {
       viewLength: sizes.viewLength,
@@ -104,6 +105,8 @@ export function Timeline() {
       lastVisibleFrame,
       density,
       segmentDensity,
+      pointerToFrames: (value: number) =>
+        conversion.pixelsToFrames(value - startPosition),
       ...conversion,
     };
   }, [sizes, conversion, duration, offset]);
@@ -168,9 +171,7 @@ export function Timeline() {
   });
 
   const scrub = (x: number) => {
-    const frame = Math.floor(
-      state.pixelsToFrames(offset - sizes.paddingLeft + x - rect.x),
-    );
+    const frame = Math.floor(state.pointerToFrames(x));
 
     seeking.value = player.clampRange(frame);
     if (player.onFrameChanged.current !== frame) {

--- a/packages/ui/src/contexts/shortcuts.tsx
+++ b/packages/ui/src/contexts/shortcuts.tsx
@@ -37,7 +37,11 @@ const InitialShortcuts: ShortcutsByModule = {
       available: () => typeof EyeDropper === 'function',
     },
   ],
-  timeline: [{key: 'F', action: 'Focus playhead'}],
+  timeline: [
+    {key: 'F', action: 'Focus playhead'},
+    {key: 'B', action: 'Move range start to playhead'},
+    {key: 'N', action: 'Move range end to playhead'},
+  ],
   none: [],
 };
 

--- a/packages/ui/src/contexts/timeline.tsx
+++ b/packages/ui/src/contexts/timeline.tsx
@@ -31,13 +31,17 @@ export interface TimelineState {
    */
   framesToPercents: (value: number) => number;
   /**
-   * Convert frames pixels
+   * Convert frames to pixels.
    */
   framesToPixels: (value: number) => number;
   /**
    * Convert pixels to frames.
    */
   pixelsToFrames: (value: number) => number;
+  /**
+   * Convert current pointer position to frames.
+   */
+  pointerToFrames: (value: number) => number;
 }
 
 const TimelineContext = createContext<TimelineState>({
@@ -50,6 +54,7 @@ const TimelineContext = createContext<TimelineState>({
   framesToPercents: value => value,
   framesToPixels: value => value,
   pixelsToFrames: value => value,
+  pointerToFrames: value => value,
 });
 
 export function TimelineContextProvider({


### PR DESCRIPTION
Add the possibility to edit the range directly by "drawing it in" when `SHIFT` and `CTRL` are pressed. To also enable this feature outside of the current range, an additional `rangeContainer` is added as well.

Additionally, pressing `B`/`N` now moves the start/end of the range to the current playhead position. These shortcuts are also added to the footer.

Closes #875 

