### PR TITLE
feat(ui): add number input dragging

### DIFF
--- a/packages/ui/src/components/controls/Controls.module.scss
+++ b/packages/ui/src/components/controls/Controls.module.scss
@@ -130,7 +130,7 @@
 .numberInput {
   cursor: ew-resize;
 
-  &.active {
+  &:focus {
     cursor: text;
   }
 }

--- a/packages/ui/src/components/controls/Controls.module.scss
+++ b/packages/ui/src/components/controls/Controls.module.scss
@@ -127,6 +127,14 @@
   }
 }
 
+.numberInput {
+  cursor: ew-resize;
+
+  &.active {
+    cursor: text;
+  }
+}
+
 .checkbox {
   width: 16px;
   height: 16px;

--- a/packages/ui/src/components/controls/NumberInput.tsx
+++ b/packages/ui/src/components/controls/NumberInput.tsx
@@ -47,13 +47,16 @@ export function NumberInput({
     [min, max, step],
   );
 
-  useDocumentEvent('pointerlockchange', () => {
-    if (document.pointerLockElement === inputRef.current) {
-      document.addEventListener('pointermove', handleDrag);
-    } else {
-      document.removeEventListener('pointermove', handleDrag);
-    }
-  });
+  useDocumentEvent(
+    'pointerlockchange',
+    useCallback(() => {
+      if (document.pointerLockElement === inputRef.current) {
+        document.addEventListener('pointermove', handleDrag);
+      } else {
+        document.removeEventListener('pointermove', handleDrag);
+      }
+    }, [handleDrag]),
+  );
 
   return (
     <input

--- a/packages/ui/src/components/controls/NumberInput.tsx
+++ b/packages/ui/src/components/controls/NumberInput.tsx
@@ -1,0 +1,126 @@
+import clsx from 'clsx';
+import type {JSX} from 'preact';
+import {useCallback, useEffect, useRef, useState} from 'preact/hooks';
+import {useDocumentEvent} from '../../hooks';
+import {MouseButton, clamp} from '../../utils';
+import styles from './Controls.module.scss';
+
+type NumberInputProps = Omit<
+  JSX.HTMLAttributes<HTMLInputElement>,
+  'min' | 'max' | 'step' | 'value' | 'onChange' | 'onChangeCapture'
+> & {
+  min?: number;
+  max?: number;
+  step?: number;
+  value: number;
+  onChange?: (value: number) => void;
+  onChangeCapture?: (value: number) => void;
+};
+
+export function NumberInput({
+  min = -Infinity,
+  max = Infinity,
+  step = 1,
+  value = 0,
+  onChange,
+  onChangeCapture,
+  ...props
+}: NumberInputProps) {
+  const handleChange = onChangeCapture ? onChange : undefined;
+  const handleChangeCapture = onChangeCapture ?? onChange;
+
+  const inputRef = useRef<HTMLInputElement>();
+  const [currentValue, setCurrentValue] = useState(value);
+  const [active, setActive] = useState(false);
+  const [startX, setStartX] = useState(0);
+
+  useEffect(() => {
+    setCurrentValue(value);
+  }, [value]);
+
+  const handleDrag = useCallback(
+    (event: MouseEvent) => {
+      setCurrentValue(value => {
+        // ignore very large jumps in movement, as they often result from
+        // mouse acceleration issues
+        if (Math.abs(event.movementX) > 100) {
+          return value;
+        }
+
+        const newValue = clamp(min, max, value + event.movementX * step);
+        handleChange?.(newValue);
+        return newValue;
+      });
+    },
+    [min, max, step],
+  );
+
+  useDocumentEvent('pointerlockchange', () => {
+    if (document.pointerLockElement === inputRef.current) {
+      document.addEventListener('pointermove', handleDrag);
+    } else {
+      document.removeEventListener('pointermove', handleDrag);
+    }
+  });
+
+  return (
+    <input
+      type={'number'}
+      ref={inputRef}
+      min={min}
+      max={max}
+      step={step}
+      value={currentValue}
+      onChangeCapture={event => {
+        const value = parseInt((event.target as HTMLInputElement).value);
+        handleChangeCapture?.(value);
+      }}
+      onChange={event => {
+        const value = parseInt((event.target as HTMLInputElement).value);
+        console.log(value);
+
+        handleChange?.(value);
+      }}
+      onPointerDown={event => {
+        if (!active && event.button === MouseButton.Left) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.currentTarget.setPointerCapture(event.pointerId);
+
+          setStartX(event.clientX);
+        }
+      }}
+      onPointerMove={event => {
+        if (!active && event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (Math.abs(startX - event.clientX) > 5) {
+            inputRef.current.requestPointerLock();
+          }
+        }
+      }}
+      onPointerUp={event => {
+        if (event.button === MouseButton.Left) {
+          event.stopPropagation();
+          event.currentTarget.releasePointerCapture(event.pointerId);
+
+          if (document.pointerLockElement === inputRef.current) {
+            document.exitPointerLock();
+            handleChangeCapture?.(currentValue);
+          } else if (!active) {
+            inputRef.current.select();
+          }
+        }
+      }}
+      onFocus={() => setActive(true)}
+      onBlur={() => setActive(false)}
+      className={clsx(
+        styles.input,
+        styles.numberInput,
+        active && styles.active,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/components/controls/NumberInputSelect.tsx
+++ b/packages/ui/src/components/controls/NumberInputSelect.tsx
@@ -5,14 +5,13 @@ import {Select, SelectProps} from './Select';
 
 export type NumberInputSelectProps = Omit<
   JSX.HTMLAttributes<HTMLInputElement>,
-  'min' | 'max' | 'step' | 'value' | 'onChange' | 'onChangeCapture'
+  'value' | 'onChange' | 'min' | 'max' | 'step'
 > &
   SelectProps<number> & {
     value: number;
     min?: number;
     max?: number;
     step?: number;
-    onChangeCapture?: (value: number) => void;
   };
 
 export function NumberInputSelect({
@@ -23,11 +22,7 @@ export function NumberInputSelect({
 }: NumberInputSelectProps) {
   return (
     <div className={styles.inputSelect}>
-      <NumberInput
-        value={value}
-        onChange={value => onChange(value)}
-        {...props}
-      />
+      <NumberInput value={value} onChange={onChange} {...props} />
       <Select value={value} options={options} onChange={onChange} />
     </div>
   );

--- a/packages/ui/src/components/controls/NumberInputSelect.tsx
+++ b/packages/ui/src/components/controls/NumberInputSelect.tsx
@@ -1,0 +1,34 @@
+import type {JSX} from 'preact';
+import styles from './Controls.module.scss';
+import {NumberInput} from './NumberInput';
+import {Select, SelectProps} from './Select';
+
+export type NumberInputSelectProps = Omit<
+  JSX.HTMLAttributes<HTMLInputElement>,
+  'min' | 'max' | 'step' | 'value' | 'onChange' | 'onChangeCapture'
+> &
+  SelectProps<number> & {
+    value: number;
+    min?: number;
+    max?: number;
+    step?: number;
+    onChangeCapture?: (value: number) => void;
+  };
+
+export function NumberInputSelect({
+  options,
+  value,
+  onChange,
+  ...props
+}: NumberInputSelectProps) {
+  return (
+    <div className={styles.inputSelect}>
+      <NumberInput
+        value={value}
+        onChange={value => onChange(value)}
+        {...props}
+      />
+      <Select value={value} options={options} onChange={onChange} />
+    </div>
+  );
+}

--- a/packages/ui/src/components/controls/index.ts
+++ b/packages/ui/src/components/controls/index.ts
@@ -8,6 +8,8 @@ export * from './IconCheckbox';
 export * from './Input';
 export * from './InputSelect';
 export * from './Label';
+export * from './NumberInput';
+export * from './NumberInputSelect';
 export * from './Pill';
 export * from './ReadOnlyInput';
 export * from './Select';

--- a/packages/ui/src/components/meta/NumberMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/NumberMetaFieldView.tsx
@@ -1,6 +1,6 @@
 import type {NumberMetaField} from '@motion-canvas/core';
 import {useSubscribableValue} from '../../hooks';
-import {Input, InputSelect} from '../controls';
+import {NumberInput, NumberInputSelect} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';
 
 export interface NumberMetaFieldViewProps {
@@ -14,8 +14,7 @@ export function NumberMetaFieldView({field}: NumberMetaFieldViewProps) {
   return (
     <MetaFieldGroup field={field}>
       {presets.length ? (
-        <InputSelect
-          type="number"
+        <NumberInputSelect
           value={value}
           onChange={value => {
             field.set(value);
@@ -23,13 +22,7 @@ export function NumberMetaFieldView({field}: NumberMetaFieldViewProps) {
           options={presets}
         />
       ) : (
-        <Input
-          type="number"
-          value={value}
-          onChange={event => {
-            field.set((event.target as HTMLInputElement).value);
-          }}
-        />
+        <NumberInput value={value} onChange={value => field.set(value)} />
       )}
     </MetaFieldGroup>
   );

--- a/packages/ui/src/components/meta/RangeMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/RangeMetaFieldView.tsx
@@ -5,7 +5,7 @@ import {
   usePreviewSettings,
   useSubscribableValue,
 } from '../../hooks';
-import {Input} from '../controls';
+import {NumberInput} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';
 
 export interface RangeMetaFieldViewProps {
@@ -24,28 +24,24 @@ export function RangeMetaFieldView({field}: RangeMetaFieldViewProps) {
 
   return (
     <MetaFieldGroup field={field}>
-      <Input
+      <NumberInput
         min={0}
         max={endFrame}
-        type={'number'}
         value={startFrame}
-        onChange={event => {
-          let start = parseInt((event.target as HTMLInputElement).value);
-          if (isNaN(start)) {
+        onChange={start => {
+          if (!start || isNaN(start)) {
             start = 0;
           }
           field.update(start, endFrame, duration, fps);
         }}
       />
-      <Input
+      <NumberInput
         min={startFrame}
         max={duration}
-        type={'number'}
         placeholder="end"
-        value={endFrame >= Infinity ? '' : endFrame}
-        onChange={event => {
-          let end = parseInt((event.target as HTMLInputElement).value);
-          if (isNaN(end)) {
+        value={endFrame >= Infinity ? null : endFrame}
+        onChange={end => {
+          if (!end || isNaN(end)) {
             end = Infinity;
           }
           field.update(startFrame, end, duration, fps);

--- a/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
+++ b/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
@@ -1,6 +1,6 @@
 import {Vector2MetaField} from '@motion-canvas/core';
 import {useSubscribableValue} from '../../hooks';
-import {Input} from '../controls';
+import {NumberInput} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';
 
 export interface Vector2MetaFieldViewProps {
@@ -12,22 +12,8 @@ export function Vector2MetaFieldView({field}: Vector2MetaFieldViewProps) {
 
   return (
     <MetaFieldGroup field={field}>
-      <Input
-        type="number"
-        value={value.x}
-        onChange={event => {
-          const x = parseInt((event.target as HTMLInputElement).value);
-          field.set([x, value.y]);
-        }}
-      />
-      <Input
-        type="number"
-        value={value.y}
-        onChange={event => {
-          const y = parseInt((event.target as HTMLInputElement).value);
-          field.set([value.x, y]);
-        }}
-      />
+      <NumberInput value={value.x} onChange={x => field.set([x, value.y])} />
+      <NumberInput value={value.y} onChange={y => field.set([value.x, y])} />
     </MetaFieldGroup>
   );
 }


### PR DESCRIPTION
Add a new `NumberInput` component that supports dragging to edit numbers. When hovering over the input, the cursor is a left-right arrow to indicate the dragging option. For the dragging behavior, the `PointerLock` API is used.

In order to edit the value manually via keyboard input, users can click the component without dragging. Dragging is then disabled and the cursor switches to a regular text cursor, allowing text selection. Up and down arrow keys are also supported through the regular `<input type="number"/>` element.

The new `NumberInput` also supports `min`, `max` and `step` properties for input via the arrow keys and via dragging.

Closes #799

https://github.com/motion-canvas/motion-canvas/assets/47495425/6677bb5c-9b73-4819-aa33-4f499ab4b337

