### PR TITLE
fix: improper cloning of custom fields

### DIFF
--- a/packages/core/src/meta/ObjectMetaField.ts
+++ b/packages/core/src/meta/ObjectMetaField.ts
@@ -72,11 +72,20 @@ class ObjectMetaFieldInternal<
   }
 
   public override serialize(): ValueOf<T> {
-    return this.transform('serialize');
+    return {
+      ...this.transform('serialize'),
+      ...this.customFields,
+    };
   }
 
   public override clone(): this {
-    return new (<any>this.constructor)(this.name, this.transform('clone'));
+    const cloned = new (<any>this.constructor)(
+      this.name,
+      this.transform('clone'),
+    );
+    cloned.customFields = structuredClone(this.customFields);
+
+    return cloned;
   }
 
   protected handleChange = () => {
@@ -91,10 +100,7 @@ class ObjectMetaFieldInternal<
       Array.from(this.fields, ([name, field]) => [name, field[fn]()]),
     ) as TransformationOf<T, TKey>;
 
-    return {
-      ...transformed,
-      ...this.customFields,
-    };
+    return transformed;
   }
 }
 

--- a/packages/core/src/meta/ObjectMetaField.ts
+++ b/packages/core/src/meta/ObjectMetaField.ts
@@ -71,6 +71,13 @@ class ObjectMetaFieldInternal<
     this.handleChange();
   }
 
+  public override get(): ValueOf<T> {
+    return {
+      ...this.value.current,
+      ...this.customFields,
+    };
+  }
+
   public override serialize(): ValueOf<T> {
     return {
       ...this.transform('serialize'),

--- a/packages/core/src/meta/ObjectMetaField.ts
+++ b/packages/core/src/meta/ObjectMetaField.ts
@@ -90,7 +90,10 @@ class ObjectMetaFieldInternal<
 
   protected handleChange = () => {
     if (this.ignoreChange) return;
-    this.value.current = this.transform('get');
+    this.value.current = {
+      ...this.transform('get'),
+      ...this.customFields,
+    };
   };
 
   protected transform<TKey extends CallableKeys<MetaField<any>>>(

--- a/packages/core/src/meta/ObjectMetaField.ts
+++ b/packages/core/src/meta/ObjectMetaField.ts
@@ -71,13 +71,6 @@ class ObjectMetaFieldInternal<
     this.handleChange();
   }
 
-  public override get(): ValueOf<T> {
-    return {
-      ...this.value.current,
-      ...this.customFields,
-    };
-  }
-
   public override serialize(): ValueOf<T> {
     return {
       ...this.transform('serialize'),

--- a/packages/core/src/meta/ObjectMetaField.ts
+++ b/packages/core/src/meta/ObjectMetaField.ts
@@ -83,7 +83,7 @@ class ObjectMetaFieldInternal<
       this.name,
       this.transform('clone'),
     );
-    cloned.customFields = structuredClone(this.customFields);
+    cloned.set(structuredClone(this.customFields));
 
     return cloned;
   }


### PR DESCRIPTION
Fixes a bug where `MetaObjectField` passes custom fields into the constructor after calling `clone`, causing the editor to crash due to missing `.get()` methods on the custom fields.