### PR TITLE
feat: expose parts of player to outside of shadow root

### DIFF
--- a/packages/player/src/template.html
+++ b/packages/player/src/template.html
@@ -1,9 +1,10 @@
-<div class="overlay">
+<div class="overlay" part="player">
   <button title="Play / Pause" class="button ready" tabindex="0"></button>
   <div class="message error">
     An error occurred while loading the animation.
   </div>
   <svg
+    part="loader"
     class="loader loading"
     viewBox="0 0 24 24"
     stroke="#ffffff"


### PR DESCRIPTION
Fixes #950 

Now I am able to:
```css
motion-canvas-player::part(player) {
  background-color: transparent;
}

motion-canvas-player::part(loader) {
  display: none;
}
```