### PR TITLE
refactor: improve template package

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,26 +54,22 @@ After cloning the repo, run `npm install` in the root of the project to install
 all necessary dependencies. Then run `npx lerna run build` to build all the
 packages.
 
-### Developing Core & 2D
+### Developing Editor
 
-When developing the core, execute both `npm run core:dev` and
-`npm run template:dev`.
+When developing the editor, run the following command:
 
-This will pick up any changes you make to the core package, automatically
-rebuild the `template` project and refresh the page.
+```bash
+npm run template:dev
+```
 
-Similarly, when developing the 2D package, execute `npm run 2d:dev` and
-`npm run template:dev`.
-
-### Developing UI
-
-If you want to develop the UI, first build the template project by running:
-`npm run template:build`. Then execute `npm run ui:dev`.
+It will start a vite server that watches the `core`, `2d`, `ui`, and
+`vite-plugin` packages. The `template` package itself contains a simple Motion
+Canvas project that can be used during development.
 
 ### Developing Player
 
-Like with UI, to develop the player, first build the template:
-`npm run template:build`. Then, start `npm run player:dev`.
+To develop the player, first build the template: `npm run template:build`. Then,
+start `npm run player:dev`.
 
 ## Installing a local version of Motion Canvas in a project
 
@@ -101,6 +97,28 @@ relative path to the package you want to link:
     // ...
   },
 ```
+
+If you're linking the `ui` package, you'll also need to modify `vite.config.ts`
+to allow vite to load external files:
+
+```ts
+import {defineConfig} from 'vite';
+import motionCanvas from '@motion-canvas/vite-plugin';
+
+export default defineConfig({
+  server: {
+    fs: {
+      // let it load external files
+      strict: false,
+    },
+  },
+  plugins: [motionCanvas()],
+});
+```
+
+This is necessary because the editor styles are loaded using the `/@fs/` prefix
+and since the linked `ui` package is outside the project, vite needs permission
+to access it.
 
 Then run `npm install` in to apply the changes and that's it.
 

--- a/packages/internal/common/marked.js
+++ b/packages/internal/common/marked.js
@@ -1,0 +1,22 @@
+const {Marked} = require('marked');
+const highlightJs = require('highlight.js');
+
+module.exports = new Marked({
+  renderer: {
+    link(href, title, text) {
+      return `<a href='${href}' target='_blank'>${text}</a>`;
+    },
+    code(code, info) {
+      const [lang, ...rest] = (info || '').split(/\s+/);
+      code = code
+        .split('\n')
+        .filter(line => !line.includes('prettier-ignore'))
+        .join('\n');
+      const language = highlightJs.getLanguage(lang) ? lang : 'plaintext';
+      const result = highlightJs.highlight(code, {language});
+      return `<pre class="${rest.join(
+        ' ',
+      )}"><code class="language-${language}">${result.value}</code></pre>`;
+    },
+  },
+});

--- a/packages/internal/transformers/markdown-literals.js
+++ b/packages/internal/transformers/markdown-literals.js
@@ -1,28 +1,7 @@
 const ts = require('typescript');
 const path = require('path');
 const fs = require('fs');
-const {Marked} = require('marked');
-const highlightJs = require('highlight.js');
-
-const marked = new Marked({
-  renderer: {
-    link(href, title, text) {
-      return `<a href='${href}' target='_blank'>${text}</a>`;
-    },
-    code(code, info) {
-      const [lang, ...rest] = (info || '').split(/\s+/);
-      code = code
-        .split('\n')
-        .filter(line => !line.includes('prettier-ignore'))
-        .join('\n');
-      const language = highlightJs.getLanguage(lang) ? lang : 'plaintext';
-      const result = highlightJs.highlight(code, {language});
-      return `<pre class="${rest.join(
-        ' ',
-      )}"><code class="language-${language}">${result.value}</code></pre>`;
-    },
-  },
-});
+const marked = require('../common/marked');
 
 const transformerProgram = program => context => sourceFile => {
   const sourceMap = new Map();

--- a/packages/internal/vite/markdown-literals.js
+++ b/packages/internal/vite/markdown-literals.js
@@ -1,8 +1,10 @@
+const marked = require('../common/marked');
+
 module.exports = () => ({
   name: 'markdown-literals',
-  async load(id) {
+  async transform(code, id) {
     if (id.endsWith('.md')) {
-      return `export default 'Mockup text';`;
+      return `export default ${JSON.stringify(marked.parse(code))};`;
     }
   },
 });

--- a/packages/template/src/project.meta
+++ b/packages/template/src/project.meta
@@ -13,7 +13,7 @@
     "audioOffset": 0
   },
   "preview": {
-    "fps": 30,
+    "fps": 60,
     "resolutionScale": 1
   },
   "rendering": {

--- a/packages/template/src/scenes/example.meta
+++ b/packages/template/src/scenes/example.meta
@@ -2,8 +2,8 @@
   "version": 1,
   "timeEvents": [
     {
-      "name": "circle",
-      "targetTime": 3
+      "name": "rect",
+      "targetTime": 0.6792665726375177
     }
   ],
   "seed": 3073416149

--- a/packages/template/src/scenes/example.tsx
+++ b/packages/template/src/scenes/example.tsx
@@ -1,15 +1,23 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {createRef, waitFor, waitUntil} from '@motion-canvas/core';
+import {Rect, makeScene2D} from '@motion-canvas/2d';
+import {
+  all,
+  createRef,
+  easeInExpo,
+  easeInOutExpo,
+  waitFor,
+  waitUntil,
+} from '@motion-canvas/core';
 
 export default makeScene2D(function* (view) {
-  const circle = createRef<Circle>();
+  const rect = createRef<Rect>();
 
   view.add(
-    <Circle ref={circle} width={320} height={320} fill={'lightseagreen'} />,
+    <Rect ref={rect} size={320} radius={80} smoothCorners fill={'#f3303f'} />,
   );
 
-  yield* waitUntil('circle');
-  yield* circle().scale(2, 2).to(1, 2);
-
-  yield* waitFor(5);
+  yield* waitUntil('rect');
+  yield* rect().scale(2, 1, easeInOutExpo).to(1, 0.6, easeInExpo);
+  rect().fill('#ffa56d');
+  yield* all(rect().ripple(1));
+  yield* waitFor(0.3);
 });

--- a/packages/template/vite.config.ts
+++ b/packages/template/vite.config.ts
@@ -1,8 +1,34 @@
-import motionCanvas from '@motion-canvas/vite-plugin';
+import markdown from '@motion-canvas/internal/vite/markdown-literals';
+import preact from '@preact/preset-vite';
 import {defineConfig} from 'vite';
+import motionCanvas from '../vite-plugin/src/main';
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@motion-canvas/ui',
+        replacement: '@motion-canvas/ui/src/main.tsx',
+      },
+      {
+        find: '@motion-canvas/2d/editor',
+        replacement: '@motion-canvas/2d/src/editor',
+      },
+      {
+        find: /@motion-canvas\/2d(\/lib)?/,
+        replacement: '@motion-canvas/2d/src/lib',
+      },
+      {find: '@motion-canvas/core', replacement: '@motion-canvas/core/src'},
+    ],
+  },
   plugins: [
+    markdown(),
+    preact({
+      include: [
+        /packages\/ui\/src\/(.*)\.tsx?$/,
+        /packages\/2d\/src\/editor\/(.*)\.tsx?$/,
+      ],
+    }),
     motionCanvas({
       buildForEditor: true,
     }),


### PR DESCRIPTION
All packages related to the editor can now be developed in unison using a single command:
```bash
npm run template:dev
```
It will start a vite server that watches the `core`, `2d`, `ui`, and
`vite-plugin` packages with proper HMR