### PR TITLE
934 slanted fonts fix

### DIFF
--- a/packages/2d/src/lib/components/TxtLeaf.ts
+++ b/packages/2d/src/lib/components/TxtLeaf.ts
@@ -139,7 +139,7 @@ export class TxtLeaf extends Shape {
       -size.height / 2,
       bbox.width,
       bbox.height,
-    ).expand(lineWidth * miterLimitCoefficient);
+    ).expand([0, this.fontSize() * 0.5 * this.absoluteScale().x]).expand(lineWidth * miterLimitCoefficient);
   }
 
   protected override applyFlex() {

--- a/packages/2d/src/lib/components/TxtLeaf.ts
+++ b/packages/2d/src/lib/components/TxtLeaf.ts
@@ -139,7 +139,9 @@ export class TxtLeaf extends Shape {
       -size.height / 2,
       bbox.width,
       bbox.height,
-    ).expand([0, this.fontSize() * 0.5 * this.absoluteScale().x]).expand(lineWidth * miterLimitCoefficient);
+    )
+      .expand([0, this.fontSize() * 0.5])
+      .expand(lineWidth * miterLimitCoefficient);
   }
 
   protected override applyFlex() {


### PR DESCRIPTION
This PR attempts to fix #934 by expanding the `BBox` returned by `getCacheBBox` for `TxtLeaf` by half of the element's font size horizontally.