### PR TITLE
feat(ui): support for PowerPoint shortcuts in presentation mode

### DIFF
--- a/packages/ui/src/components/presentation/PresentationControls.tsx
+++ b/packages/ui/src/components/presentation/PresentationControls.tsx
@@ -36,6 +36,7 @@ export function PresentationControls() {
             event.preventDefault();
             presenter.resume();
             break;
+          case 'PageUp':
           case 'ArrowLeft':
             event.preventDefault();
             if (event.shiftKey) {
@@ -44,6 +45,7 @@ export function PresentationControls() {
             }
             presenter.requestPreviousSlide();
             break;
+          case 'PageDown':
           case 'ArrowRight':
             event.preventDefault();
             if (event.shiftKey) {


### PR DESCRIPTION
Continuation of #978. Added PowerPoint shortcuts for next/previous slide in presentation mode. Sorry for the second PR, I made some mess on my `main` branch and had to do this the proper way.