### PR TITLE
fix(core): reset playback state on presentation abort

### DIFF
--- a/packages/core/src/app/PlaybackManager.ts
+++ b/packages/core/src/app/PlaybackManager.ts
@@ -153,6 +153,7 @@ export class PlaybackManager {
     this.previousScene = null;
     this.currentScene = this.scenes.current[0];
     this.frame = 0;
+    this.finished = false;
     await this.currentScene.reset();
   }
 

--- a/packages/core/src/app/Presenter.ts
+++ b/packages/core/src/app/Presenter.ts
@@ -123,11 +123,10 @@ export class Presenter {
   /**
    * Abort the ongoing presentation process.
    */
-  public async abort() {
+  public abort() {
     if (this.state.current === PresenterState.Initial) return;
     this.abortController?.abort();
     this.state.current = PresenterState.Aborting;
-    await this.playback.reset();
   }
 
   /**

--- a/packages/core/src/app/Presenter.ts
+++ b/packages/core/src/app/Presenter.ts
@@ -123,10 +123,11 @@ export class Presenter {
   /**
    * Abort the ongoing presentation process.
    */
-  public abort() {
+  public async abort() {
     if (this.state.current === PresenterState.Initial) return;
     this.abortController?.abort();
     this.state.current = PresenterState.Aborting;
+    await this.playback.reset();
   }
 
   /**


### PR DESCRIPTION
Hi,

I discovered a bug in the presentation mode. When entering the presentation mode and playing it until the last slide (so getting into the `finished` state), when closing the presentation and opening it again, it was not possible to start playing the slides, even though the play button is active (clicking on it had no effect).

After going through the code, I discovered that on `abort` the finished state is never reset.

For the fix, I was not sure if a separate method was needed to only update the `finished` flag, or an actual `playback.reset` was needed (which I did in the end).