### PR TITLE
feat(2d): add camera node

### DIFF
--- a/packages/2d/src/lib/components/Camera.ts
+++ b/packages/2d/src/lib/components/Camera.ts
@@ -37,8 +37,8 @@ export interface CameraProps extends NodeProps {
  *
  * @preview
  * ```tsx editor
- * import {all} from '@motion-canvas/core';
- * import {Camera, Rect, Circle} from '@motion-canvas/2d';
+ * import {Camera, Circle, makeScene2D, Rect} from '@motion-canvas/2d';
+ * import {all, createRef} from '@motion-canvas/core';
  *
  * export default makeScene2D(function* (view) {
  *   const camera = createRef<Camera>();
@@ -46,27 +46,31 @@ export interface CameraProps extends NodeProps {
  *   const circle = createRef<Circle>();
  *
  *   view.add(
- *     <Camera ref={camera}>
- *       <Rect
- *         ref={rect}
- *         fill={'lightseagreen'}
- *         size={200}
- *         position={[300, -200]}
- *       />
- *       <Circle
- *         ref={circle}
- *         fill={'hotpink'}
- *         size={180}
- *         position={[-300, 200]}
- *       />
- *     </Camera>
+ *     <>
+ *       <Camera ref={camera}>
+ *         <Rect
+ *           ref={rect}
+ *           fill={'lightseagreen'}
+ *           size={100}
+ *           position={[100, -50]}
+ *         />
+ *         <Circle
+ *           ref={circle}
+ *           fill={'hotpink'}
+ *           size={120}
+ *           position={[-100, 50]}
+ *         />
+ *       </Camera>
+ *     </>,
  *   );
  *
- *   yield* camera().centerOn(rect(), 2);
  *   yield* all(
- *     camera().centerOn(circle(), 2),
- *     camera().zoom(2, 2),
+ *     camera().centerOn(rect(), 3),
+ *     camera().rotation(180, 3),
+ *     camera().zoom(1.8, 3),
  *   );
+ *   yield* camera().centerOn(circle(), 2);
+ *   yield* camera().reset(1);
  * });
  * ```
  */
@@ -149,30 +153,37 @@ export class Camera extends Node {
    *
    * @param position - The position to center the camera on.
    * @param duration - The duration of the tween.
-   * @param timing - The timing function to use for the tween.
+   * @param timingFunction - The timing function to use for the tween.
+   * @param interpolationFunction - The interpolation function to use for the
+   * tween.
    */
   public centerOn(
     position: PossibleVector2,
     duration: number,
-    timing?: TimingFunction,
+    timingFunction?: TimingFunction,
+    interpolationFunction?: InterpolationFunction<Vector2>,
   ): ThreadGenerator;
   /**
    * Centers the camera on the specified node without changing the zoom level.
    *
    * @param node - The node to center the camera on.
    * @param duration - The duration of the tween.
-   * @param timing - The timing function to use for the tween.
+   * @param timingFunction - The timing function to use for the tween.
+   * @param interpolationFunction - The interpolation function to use for the
+   * tween.
    */
   public centerOn(
     node: Node,
     duration: number,
-    timing?: TimingFunction,
+    timingFunction?: TimingFunction,
+    interpolationFunction?: InterpolationFunction<Vector2>,
   ): ThreadGenerator;
   @threadable()
   public *centerOn(
     positionOrNode: Node | PossibleVector2,
     duration: number,
     timing: TimingFunction = easeInOutCubic,
+    interpolationFunction: InterpolationFunction<Vector2> = Vector2.lerp,
   ): ThreadGenerator {
     const position =
       positionOrNode instanceof Node
@@ -180,14 +191,17 @@ export class Camera extends Node {
             .absolutePosition()
             .transformAsPoint(this.scene().worldToLocal())
         : positionOrNode;
-    yield* this.position(position, duration, timing);
+    yield* this.position(position, duration, timing, interpolationFunction);
   }
 
   /**
    * Makes the camera follow a path specified by the provided curve.
    *
    * @remarks
-   * This will not change the orientation of the camera.
+   * This will not change the orientation of the camera. To make the camera
+   * orient itself along the curve, use {@link followCurveWithRotation} or
+   * {@link followCurveWithRotationReverse}.
+   *
    * If you want to follow the curve in reverse, use {@link followCurveReverse}.
    *
    * @param curve - The curve to follow.
@@ -214,8 +228,11 @@ export class Camera extends Node {
    * Makes the camera follow a path specified by the provided curve in reverse.
    *
    * @remarks
-   * This will not change the orientation of the camera.
-   * If you want to follow the curve in forward, use {@link followCurve}.
+   * This will not change the orientation of the camera. To make the camera
+   * orient itself along the curve, use {@link followCurveWithRotation} or
+   * {@link followCurveWithRotationReverse}.
+   *
+   * If you want to follow the curve forward, use {@link followCurve}.
    *
    * @param curve - The curve to follow.
    * @param duration - The duration of the tween.
@@ -234,6 +251,70 @@ export class Camera extends Node {
         .position.transformAsPoint(curve.localToWorld());
 
       this.position(point);
+    });
+  }
+
+  /**
+   * Makes the camera follow a path specified by the provided curve while
+   * pointing the camera the direction of the tangent.
+   *
+   * @remarks
+   * To make the camera follow the curve without changing its orientation, use
+   * {@link followCurve} or {@link followCurveReverse}.
+   *
+   * If you want to follow the curve in reverse, use
+   * {@link followCurveWithRotationReverse}.
+   *
+   * @param curve - The curve to follow.
+   * @param duration - The duration of the tween.
+   * @param timing - The timing function to use for the tween.
+   */
+  @threadable()
+  public *followCurveWithRotation(
+    curve: Curve,
+    duration: number,
+    timing: TimingFunction = easeInOutCubic,
+  ) {
+    yield* tween(duration, value => {
+      const t = timing(value);
+      const {position, normal} = curve.getPointAtPercentage(t);
+      const point = position.transformAsPoint(curve.localToWorld());
+      const angle = normal.flipped.perpendicular.degrees;
+
+      this.position(point);
+      this.rotation(angle);
+    });
+  }
+
+  /**
+   * Makes the camera follow a path specified by the provided curve in reverse
+   * while pointing the camera the direction of the tangent.
+   *
+   * @remarks
+   * To make the camera follow the curve without changing its orientation, use
+   * {@link followCurve} or {@link followCurveReverse}.
+   *
+   * If you want to follow the curve forward, use
+   * {@link followCurveWithRotation}.
+   *
+   * @param curve - The curve to follow.
+   * @param duration - The duration of the tween.
+   * @param timing - The timing function to use for the tween.
+   */
+  @threadable()
+  public *followCurveWithRotationReverse(
+    curve: Curve,
+    duration: number,
+    timing: TimingFunction = easeInOutCubic,
+  ) {
+    yield* tween(duration, value => {
+      const t = timing(value);
+      const {position, normal} = curve.getPointAtPercentage(t);
+      const point = position.transformAsPoint(curve.localToWorld());
+      const angle = normal.flipped.perpendicular.degrees;
+
+      this.position(point);
+      this.rotation(angle);
     });
   }
 

--- a/packages/2d/src/lib/components/Camera.ts
+++ b/packages/2d/src/lib/components/Camera.ts
@@ -308,7 +308,7 @@ export class Camera extends Node {
     timing: TimingFunction = easeInOutCubic,
   ) {
     yield* tween(duration, value => {
-      const t = timing(value);
+      const t = 1 - timing(value);
       const {position, normal} = curve.getPointAtPercentage(t);
       const point = position.transformAsPoint(curve.localToWorld());
       const angle = normal.flipped.perpendicular.degrees;

--- a/packages/2d/src/lib/components/Camera.ts
+++ b/packages/2d/src/lib/components/Camera.ts
@@ -1,0 +1,278 @@
+import {
+  all,
+  DEFAULT,
+  easeInOutCubic,
+  InterpolationFunction,
+  modify,
+  PossibleVector2,
+  Reference,
+  SignalValue,
+  SimpleSignal,
+  threadable,
+  ThreadGenerator,
+  TimingFunction,
+  tween,
+  unwrap,
+  Vector2,
+} from '@motion-canvas/core';
+import {cloneable, signal} from '../decorators';
+import {Curve} from './Curve';
+import {Node, NodeProps} from './Node';
+import {Rect, RectProps} from './Rect';
+
+export interface CameraProps extends NodeProps {
+  /**
+   * {@inheritDoc Camera.scene}
+   */
+  scene?: Node;
+
+  /**
+   * {@inheritDoc Camera.zoom}
+   */
+  zoom?: SignalValue<number>;
+}
+
+/**
+ * A node representing an orthographic camera.
+ *
+ * @preview
+ * ```tsx editor
+ * import {all} from '@motion-canvas/core';
+ * import {Camera, Rect, Circle} from '@motion-canvas/2d';
+ *
+ * export default makeScene2D(function* (view) {
+ *   const camera = createRef<Camera>();
+ *   const rect = createRef<Rect>();
+ *   const circle = createRef<Circle>();
+ *
+ *   view.add(
+ *     <Camera ref={camera}>
+ *       <Rect
+ *         ref={rect}
+ *         fill={'lightseagreen'}
+ *         size={200}
+ *         position={[300, -200]}
+ *       />
+ *       <Circle
+ *         ref={circle}
+ *         fill={'hotpink'}
+ *         size={180}
+ *         position={[-300, 200]}
+ *       />
+ *     </Camera>
+ *   );
+ *
+ *   yield* camera().centerOn(rect(), 2);
+ *   yield* all(
+ *     camera().centerOn(circle(), 2),
+ *     camera().zoom(2, 2),
+ *   );
+ * });
+ * ```
+ */
+export class Camera extends Node {
+  /**
+   * The scene node that the camera is rendering.
+   */
+  @signal()
+  public declare readonly scene: SimpleSignal<Node, this>;
+
+  public constructor({children, ...props}: CameraProps) {
+    super(props);
+
+    if (!this.scene()) {
+      this.scene(new Node({}));
+    }
+
+    if (children) {
+      this.scene().add(children);
+    }
+  }
+
+  /**
+   * The zoom level of the camera.
+   *
+   * @defaultValue 1
+   */
+  @cloneable(false)
+  @signal()
+  public declare readonly zoom: SimpleSignal<number, this>;
+
+  protected getZoom(): number {
+    return 1 / this.scale.x();
+  }
+
+  protected setZoom(value: SignalValue<number>) {
+    this.scale(modify(value, unwrapped => 1 / unwrapped));
+  }
+
+  protected getDefaultZoom() {
+    return this.scale.x.context.getInitial();
+  }
+
+  protected *tweenZoom(
+    value: SignalValue<number>,
+    duration: number,
+    timingFunction: TimingFunction,
+    interpolationFunction: InterpolationFunction<number>,
+  ): ThreadGenerator {
+    const from = this.scale.x();
+    yield* tween(duration, v => {
+      this.zoom(
+        1 / interpolationFunction(from, 1 / unwrap(value), timingFunction(v)),
+      );
+    });
+  }
+
+  /**
+   * Resets the camera's position, rotation and zoom level to their original
+   * values.
+   *
+   * @param duration - The duration of the tween.
+   * @param timingFunction - The timing function to use for the tween.
+   */
+  @threadable()
+  public *reset(
+    duration: number,
+    timingFunction: TimingFunction = easeInOutCubic,
+  ): ThreadGenerator {
+    yield* all(
+      this.position(DEFAULT, duration, timingFunction),
+      this.zoom(DEFAULT, duration, timingFunction),
+      this.rotation(DEFAULT, duration, timingFunction),
+    );
+  }
+
+  /**
+   * Centers the camera on the specified position without changing the zoom
+   * level.
+   *
+   * @param position - The position to center the camera on.
+   * @param duration - The duration of the tween.
+   * @param timing - The timing function to use for the tween.
+   */
+  public centerOn(
+    position: PossibleVector2,
+    duration: number,
+    timing?: TimingFunction,
+  ): ThreadGenerator;
+  /**
+   * Centers the camera on the specified node without changing the zoom level.
+   *
+   * @param node - The node to center the camera on.
+   * @param duration - The duration of the tween.
+   * @param timing - The timing function to use for the tween.
+   */
+  public centerOn(
+    node: Node,
+    duration: number,
+    timing?: TimingFunction,
+  ): ThreadGenerator;
+  @threadable()
+  public *centerOn(
+    positionOrNode: Node | PossibleVector2,
+    duration: number,
+    timing: TimingFunction = easeInOutCubic,
+  ): ThreadGenerator {
+    const position =
+      positionOrNode instanceof Node
+        ? positionOrNode
+            .absolutePosition()
+            .transformAsPoint(this.scene().worldToLocal())
+        : positionOrNode;
+    yield* this.position(position, duration, timing);
+  }
+
+  /**
+   * Makes the camera follow a path specified by the provided curve.
+   *
+   * @remarks
+   * This will not change the orientation of the camera.
+   * If you want to follow the curve in reverse, use {@link followCurveReverse}.
+   *
+   * @param curve - The curve to follow.
+   * @param duration - The duration of the tween.
+   * @param timing - The timing function to use for the tween.
+   */
+  @threadable()
+  public *followCurve(
+    curve: Curve,
+    duration: number,
+    timing: TimingFunction = easeInOutCubic,
+  ): ThreadGenerator {
+    yield* tween(duration, value => {
+      const t = timing(value);
+      const point = curve
+        .getPointAtPercentage(t)
+        .position.transformAsPoint(curve.localToWorld());
+
+      this.position(point);
+    });
+  }
+
+  /**
+   * Makes the camera follow a path specified by the provided curve in reverse.
+   *
+   * @remarks
+   * This will not change the orientation of the camera.
+   * If you want to follow the curve in forward, use {@link followCurve}.
+   *
+   * @param curve - The curve to follow.
+   * @param duration - The duration of the tween.
+   * @param timing - The timing function to use for the tween.
+   */
+  @threadable()
+  public *followCurveReverse(
+    curve: Curve,
+    duration: number,
+    timing: TimingFunction = easeInOutCubic,
+  ) {
+    yield* tween(duration, value => {
+      const t = 1 - timing(value);
+      const point = curve
+        .getPointAtPercentage(t)
+        .position.transformAsPoint(curve.localToWorld());
+
+      this.position(point);
+    });
+  }
+
+  protected override transformContext(context: CanvasRenderingContext2D) {
+    const matrix = this.localToParent().inverse();
+    context.transform(
+      matrix.a,
+      matrix.b,
+      matrix.c,
+      matrix.d,
+      matrix.e,
+      matrix.f,
+    );
+  }
+
+  public override hit(position: Vector2): Node | null {
+    const local = position.transformAsPoint(this.localToParent());
+    return this.scene().hit(local);
+  }
+
+  protected override drawChildren(context: CanvasRenderingContext2D) {
+    (this.scene() as Camera).drawChildren(context);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public static Stage({
+    children,
+    cameraRef,
+    scene,
+    ...props
+  }: RectProps & {cameraRef?: Reference<Camera>; scene?: Node}) {
+    const camera = new Camera({scene: scene, children});
+
+    cameraRef?.(camera);
+
+    return new Rect({
+      clip: true,
+      ...props,
+      children: [camera],
+    });
+  }
+}

--- a/packages/2d/src/lib/components/index.ts
+++ b/packages/2d/src/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Bezier';
+export * from './Camera';
 export * from './Circle';
 export * from './Code';
 export * from './CubicBezier';

--- a/packages/2d/src/lib/scenes/Scene2D.ts
+++ b/packages/2d/src/lib/scenes/Scene2D.ts
@@ -113,23 +113,28 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
     if (node) {
       this.execute(() => {
         const cameras = this.getView().findAll(is(Camera));
-        const matrices = [];
+        const parentCameras = [];
         for (const camera of cameras) {
           const scene = camera.scene();
           if (!scene) continue;
 
           if (scene === node || scene.findFirst(n => n === node)) {
-            matrices.push(
-              camera.localToParent().inverse().multiply(camera.parentToWorld()),
-            );
+            parentCameras.push(camera);
           }
         }
 
-        if (matrices.length > 0) {
-          for (const m of matrices) {
+        if (parentCameras.length > 0) {
+          for (const camera of parentCameras) {
+            const cameraParentToWorld = camera.parentToWorld();
+            const cameraLocalToParent = camera.localToParent().inverse();
+            const nodeLocalToWorld = node.localToWorld();
+
             node.drawOverlay(
               context,
-              matrix.multiply(m).multiply(node.localToParent()),
+              matrix
+                .multiply(cameraParentToWorld)
+                .multiply(cameraLocalToParent)
+                .multiply(nodeLocalToWorld),
             );
           }
         } else {

--- a/packages/docs/docs/getting-started/camera.mdx
+++ b/packages/docs/docs/getting-started/camera.mdx
@@ -476,4 +476,4 @@ export default makeScene2D(function* (view) {
 ```
 
 [camera]: /api/2d/components/Camera
-[quad-bezier]: /docs/components/bezier-curves
+[quad-bezier]: /docs/bezier-curves

--- a/packages/docs/docs/getting-started/camera.mdx
+++ b/packages/docs/docs/getting-started/camera.mdx
@@ -87,8 +87,8 @@ won't have any visible effect on the scene until you start animating it.
 
 ### Moving the camera
 
-There are two ways of moving the camera. To move the camera relative to its
-current position, you can use the `shift` method.
+There are two ways of moving the camera. You can either directly use the
+camera's `position` signal like you would for any other component.
 
 ```tsx editor
 import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
@@ -104,15 +104,15 @@ export default makeScene2D(function* (view) {
     </Camera>,
   );
 
-  yield* camera().shift([-100, -30], 1);
-  yield* camera().shift([200, 0], 1);
-  yield* camera().shift([-100, 30], 1);
+  yield* camera().position([-100, -30], 1);
+  yield* camera().position([100, -30], 1);
+  yield* camera().position(0, 1);
 });
 ```
 
-To center the camera on a specific position or object, you can use the
-`centerOn` method. If you directly pass an object to `centerOn`, the camera will
-center on the object's position.
+Alternatively, you can center the camera on a specific position or object with
+the `centerOn` method. If you directly pass an object to `centerOn`, the camera
+will center on the object's position.
 
 ```tsx editor
 import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
@@ -232,48 +232,12 @@ Note that this uses the camera's current position as the center of rotation.
 
 ### Resetting the camera
 
-You can use the `resetPosition`, `resetZoom`, and `resetRotation` methods to
-reset the camera's position, zoom level, and rotation, respectively. To reset
-all properties at once, you can use the `reset` method.
+To reset the camera's position, zoom level, and rotation to their default
+values, you can use the `reset` method.
 
 ```tsx
-// Reset only the camera's position
-camera().resetPosition(1);
-
-// Reset only the camera's zoom
-camera().resetZoom(1);
-
-// Reset only the camera's rotation
-camera().resetRotation(1);
-
-// Reset all camera properties
+// Resets the camera's position to [0, 0], zoom to 1, and rotation to 0.
 camera().reset(1);
-```
-
-One important detail to keep in mind is that the `reset*` methods will reset the
-camera's properties to the values the camera was _initialized with_. This means
-that if you set the camera's `rotation` to 30 when mounting it, calling
-`resetRotation` will reset the rotation to 30, not 0.
-
-```tsx editor
-import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
-
-export default makeScene2D(function* (view) {
-  const camera = createRef<Camera>();
-
-  view.add(
-    <Camera ref={camera} rotation={30}>
-      <Rect size={100} fill={'lightseagreen'} position={[-100, -30]} />
-      <Circle size={80} fill={'hotpink'} position={[100, 30]} />
-    </Camera>,
-  );
-
-  yield* camera().rotation(-30, 1.5);
-  // This will reset the rotation to 30, not 0, because
-  // the camera's initial rotation was set to 30.
-  yield* camera().resetRotation(1);
-});
 ```
 
 ### Moving along a path

--- a/packages/docs/docs/getting-started/camera.mdx
+++ b/packages/docs/docs/getting-started/camera.mdx
@@ -1,0 +1,515 @@
+---
+sidebar_position: 12
+slug: /camera
+---
+
+# Camera
+
+Motion Canvas ships with a simple orthographic camera that allows you to pan,
+zoom, and rotate the viewport of the scene without having to transform the
+individual objects in your scene.
+
+```tsx editor mode=preview
+import {Camera, Circle, makeScene2D, Rect} from '@motion-canvas/2d';
+import {all, createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+  const rect = createRef<Rect>();
+  const circle = createRef<Circle>();
+
+  view.add(
+    <>
+      <Camera ref={camera}>
+        <Rect
+          ref={rect}
+          fill={'lightseagreen'}
+          size={100}
+          position={[100, -50]}
+        />
+        <Circle
+          ref={circle}
+          fill={'hotpink'}
+          size={120}
+          position={[-100, 50]}
+        />
+      </Camera>
+    </>,
+  );
+
+  yield* all(
+    camera().centerOn(rect(), 3),
+    camera().rotation(180, 3),
+    camera().zoom(1.8, 3),
+  );
+  yield* camera().centerOn(circle(), 2);
+  yield* camera().reset(1);
+});
+```
+
+## Basic usage
+
+The quickest way to get started is to wrap your scene in a [`Camera`][camera]
+component and grab a reference to it.
+
+```tsx
+// highlight-start
+import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
+//highlight-end
+import {createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  // highlight-start
+  const camera = createRef<Camera>();
+  //highlight-end
+
+  view.add(
+    // highlight-start
+    <Camera ref={camera}>
+      //highlight-end
+      <Rect size={100} fill={'lightseagreen'} position={[-100, -30]} />
+      <Circle size={80} fill={'hotpink'} position={[100, 30]} />
+      // highlight-start
+    </Camera>,
+    //highlight-end
+  );
+});
+```
+
+You can then use the camera reference to manipulate the camera in your scene.
+
+:::info
+
+By default, the [`Camera`][camera] component is completely pass-through. It
+won't have any visible effect on the scene until you start animating it.
+
+:::
+
+### Moving the camera
+
+There are two ways of moving the camera. To move the camera relative to its
+current position, you can use the `shift` method.
+
+```tsx editor
+import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+
+  view.add(
+    <Camera ref={camera}>
+      <Rect size={100} fill={'lightseagreen'} position={[-100, -30]} />
+      <Circle size={80} fill={'hotpink'} position={[100, 30]} />
+    </Camera>,
+  );
+
+  yield* camera().shift([-100, -30], 1);
+  yield* camera().shift([200, 0], 1);
+  yield* camera().shift([-100, 30], 1);
+});
+```
+
+To center the camera on a specific position or object, you can use the
+`centerOn` method. If you directly pass an object to `centerOn`, the camera will
+center on the object's position.
+
+```tsx editor
+import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+  const rect = createRef<Rect>();
+  const circle = createRef<Circle>();
+
+  view.add(
+    <Camera ref={camera}>
+      <Rect
+        ref={rect}
+        size={100}
+        fill={'lightseagreen'}
+        position={[-100, -30]}
+      />
+      <Circle ref={circle} size={80} fill={'hotpink'} position={[100, 30]} />
+    </Camera>,
+  );
+
+  yield* camera().centerOn(rect(), 1);
+  yield* camera().centerOn(circle(), 1);
+});
+```
+
+You can also directly pass a position to `centerOn`. In this case, the camera
+will center on the specified position **in world space**.
+
+```tsx editor
+import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+
+  view.add(
+    <Camera ref={camera}>
+      <Rect size={100} fill={'lightseagreen'} position={[-100, -30]} />
+      <Circle size={80} fill={'hotpink'} position={[100, 30]} />
+    </Camera>,
+  );
+
+  yield* camera().centerOn([-200, 50], 1);
+  yield* camera().centerOn([150, -30], 1.5);
+  yield* camera().centerOn(0, 1);
+});
+```
+
+### Zooming
+
+To zoom the camera in or out, you can use the `zoom` method.
+
+```tsx editor
+import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+
+  view.add(
+    <Camera ref={camera}>
+      <Rect size={100} fill={'lightseagreen'} position={[-100, -30]} />
+      <Circle size={80} fill={'hotpink'} position={[100, 30]} />
+    </Camera>,
+  );
+
+  yield* camera().zoom(2, 1);
+  yield* camera().zoom(0.5, 1.5);
+  yield* camera().zoom(1, 1);
+});
+```
+
+:::danger
+
+You should not manipulate the `scale` property of the camera directly. This is
+because the `Camera` component does some additional work internally to make sure
+that animating the zoom level of the camera works properly when combined with
+other camera animations.
+
+:::
+
+You can also use the `to` method to fluently chain multiple animations.
+
+```diff
+- yield* camera().zoom(2, 1);
+- yield* camera().zoom(0.5, 1.5);
+- yield* camera().zoom(1, 1);
++ yield* camera().zoom(2, 1).to(0.5, 1.5).to(1, 1);
+```
+
+### Rotating the camera
+
+Since [`Camera`][camera] is a regular component, you can change its rotation the
+same way you would with any other component by using the `rotation` signal.
+
+```tsx editor
+import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+
+  view.add(
+    <Camera ref={camera}>
+      <Rect size={100} fill={'lightseagreen'} position={[-100, -30]} />
+      <Circle size={80} fill={'hotpink'} position={[100, 30]} />
+    </Camera>,
+  );
+
+  yield* camera().rotation(50, 1).to(-120, 2).to(0, 1);
+});
+```
+
+Note that this uses the camera's current position as the center of rotation.
+
+### Resetting the camera
+
+You can use the `resetPosition`, `resetZoom`, and `resetRotation` methods to
+reset the camera's position, zoom level, and rotation, respectively. To reset
+all properties at once, you can use the `reset` method.
+
+```tsx
+// Reset only the camera's position
+camera().resetPosition(1);
+
+// Reset only the camera's zoom
+camera().resetZoom(1);
+
+// Reset only the camera's rotation
+camera().resetRotation(1);
+
+// Reset all camera properties
+camera().reset(1);
+```
+
+One important detail to keep in mind is that the `reset*` methods will reset the
+camera's properties to the values the camera was _initialized with_. This means
+that if you set the camera's `rotation` to 30 when mounting it, calling
+`resetRotation` will reset the rotation to 30, not 0.
+
+```tsx editor
+import {makeScene2D, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+
+  view.add(
+    <Camera ref={camera} rotation={30}>
+      <Rect size={100} fill={'lightseagreen'} position={[-100, -30]} />
+      <Circle size={80} fill={'hotpink'} position={[100, 30]} />
+    </Camera>,
+  );
+
+  yield* camera().rotation(-30, 1.5);
+  // This will reset the rotation to 30, not 0, because
+  // the camera's initial rotation was set to 30.
+  yield* camera().resetRotation(1);
+});
+```
+
+### Moving along a path
+
+You can make the camera follow a path by using the `followCurve` method. This
+method accepts any object that extends the `Curve` class. Many of the shapes
+that come with Motion Canvas, such as `Rect`, `Circle`, `Polygon`, and `Spline`
+extend the `Curve` class and can be used as paths.
+
+The following example shows the camera following the path defined by a
+[quadratic Bézier curve][quad-bezier]. Note that the path doesn't have to be
+visible or even be part of the scene. This is only done here for demonstration
+purposes.
+
+```tsx editor
+import {makeScene2D, Camera, QuadBezier} from '@motion-canvas/2d';
+import {createRef, linear} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera = createRef<Camera>();
+  const path = createRef<QuadBezier>();
+
+  view.add(
+    <Camera ref={camera}>
+      <QuadBezier
+        ref={path}
+        lineWidth={6}
+        stroke={'lightseagreen'}
+        p0={[-200, 0]}
+        p1={[0, 200]}
+        p2={[200, 0]}
+      />
+    </Camera>,
+  );
+
+  yield* camera().followCurve(path(), 2.5, linear);
+});
+```
+
+## Using multiple cameras in a scene
+
+Motion Canvas also provides a way to render the same scene to multiple cameras.
+This can be useful for creating split-screen views or for rendering the same
+scene from different perspectives.
+
+Rendering the same scene to multiple cameras requires a slightly different
+setup.
+
+First, instead of adding the scene we want to render directly to the view, we
+instead store it in a variable.
+
+```tsx
+const scene = (
+  <Node>
+    <Rect size={70} fill={'lightseagreen'} position={[-100, -30]} />
+    <Circle size={50} fill={'hotpink'} position={[100, 30]} />
+  </Node>
+);
+```
+
+Next, for each camera we want to show, we add a `Camera.Stage` component to the
+view and pass the scene to the `scene` prop.
+
+```tsx
+const scene = /* ... */
+
+const camera1 = createRef<Camera>();
+const camera2 = createRef<Camera>();
+
+view.add(
+  <>
+    <Camera.Stage
+      cameraRef={camera1}
+      size={[300, 200]}
+      position={[-180, 0]}
+      scene={scene}
+    />
+    <Camera.Stage
+      cameraRef={camera2}
+      size={[300, 200]}
+      position={[180, 0]}
+      scene={scene}
+    />
+  </>,
+);
+```
+
+The `cameraRef` prop provides a reference to the stage's camera. You can then
+use these references to manipulate each camera independently.
+
+:::danger
+
+`Camera.Stage` requires a single top-level node as its `scene` prop. A common
+source of errors is using a fragment (`<></>`) when defining the scene.
+
+The following scene will cause an error when passed to `Camera.Stage`:
+
+```tsx
+const scene = (
+  <>
+    <Circle />
+    <Rect />
+  </>
+);
+```
+
+Instead, wrap the scene in a single node like this:
+
+```tsx
+const scene = (
+  <Node>
+    <Circle />
+    <Rect />
+  </Node>
+);
+```
+
+:::
+
+:::tip
+
+Unlike the `Camera` component, `Camera.Stage` requires an explicit size to be
+set. The stage will automatically clip the scene to the specified size.
+
+:::
+
+```tsx editor
+import {makeScene2D, Node, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {all, createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera1 = createRef<Camera>();
+  const camera2 = createRef<Camera>();
+  const rect = createRef<Rect>();
+  const circle = createRef<Circle>();
+
+  const scene = (
+    <Node>
+      <Rect
+        ref={rect}
+        size={70}
+        fill={'lightseagreen'}
+        position={[-100, -30]}
+      />
+      <Circle ref={circle} size={50} fill={'hotpink'} position={[100, 30]} />
+    </Node>
+  );
+
+  view.add(
+    <>
+      <Camera.Stage
+        cameraRef={camera1}
+        scene={scene}
+        size={[300, 200]}
+        position={[-180, 0]}
+        fill={'#ccc'}
+        radius={10}
+        smoothCorners
+      />
+      <Camera.Stage
+        cameraRef={camera2}
+        scene={scene}
+        size={[300, 200]}
+        position={[180, 0]}
+        fill={'#ccc'}
+        radius={10}
+        smoothCorners
+      />
+    </>,
+  );
+
+  yield* all(camera1().centerOn(rect(), 1), camera2().centerOn(circle(), 1));
+  yield* all(camera1().centerOn(circle(), 1), camera2().centerOn(rect(), 1));
+  yield* all(camera1().zoom(1.5, 1), camera2().zoom(0.5, 1));
+  yield* all(camera1().reset(1), camera2().reset(1));
+});
+```
+
+The benefit of doing this compared to simply rendering the same scene twice is
+that any changes made to the scene will be reflected in both cameras.
+
+```tsx editor
+import {makeScene2D, Node, Camera, Rect, Circle} from '@motion-canvas/2d';
+import {all, createRef} from '@motion-canvas/core';
+
+export default makeScene2D(function* (view) {
+  const camera1 = createRef<Camera>();
+  const camera2 = createRef<Camera>();
+  const rect = createRef<Rect>();
+  const circle = createRef<Circle>();
+
+  const scene = (
+    <Node>
+      <Rect
+        ref={rect}
+        size={70}
+        fill={'lightseagreen'}
+        position={[-100, -30]}
+      />
+      <Circle ref={circle} size={50} fill={'hotpink'} position={[100, 30]} />
+    </Node>
+  );
+
+  view.add(
+    <>
+      <Camera.Stage
+        cameraRef={camera1}
+        scene={scene}
+        size={[300, 200]}
+        position={[-180, 0]}
+        fill={'#ccc'}
+        radius={10}
+        smoothCorners
+      />
+      <Camera.Stage
+        cameraRef={camera2}
+        scene={scene}
+        size={[300, 200]}
+        position={[180, 0]}
+        fill={'#ccc'}
+        radius={10}
+        smoothCorners
+      />
+    </>,
+  );
+
+  yield* all(
+    camera1().centerOn(rect(), 1),
+    camera2().centerOn(circle(), 1),
+    rect().fill('lightcoral', 1),
+    circle().fill('steelblue', 1),
+  );
+  yield* all(camera1().reset(1), camera2().reset(1));
+  yield* all(rect().fill('lightseagreen', 1), circle().fill('hotpink', 1));
+});
+```
+
+[camera]: /api/2d/components/Camera
+[quad-bezier]: /docs/components/bezier-curves

--- a/packages/docs/docs/getting-started/configuration.mdx
+++ b/packages/docs/docs/getting-started/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 slug: /configuration
 ---
 

--- a/packages/docs/docs/getting-started/logging.mdx
+++ b/packages/docs/docs/getting-started/logging.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 slug: /logging
 ---
 

--- a/packages/docs/docs/getting-started/media.mdx
+++ b/packages/docs/docs/getting-started/media.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 slug: /media
 ---
 

--- a/packages/docs/docs/getting-started/presentation.mdx
+++ b/packages/docs/docs/getting-started/presentation.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 slug: /presentation
 ---
 

--- a/packages/docs/docs/getting-started/rendering/index.mdx
+++ b/packages/docs/docs/getting-started/rendering/index.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 slug: /rendering
 ---
 


### PR DESCRIPTION
This PR adds an orthographic camera node.

There a still a few kinks that I'd like to work out before merging this:

- The `hit` method selects the correct object, but the actual overlay in the editor is offset. I'm not sure why this happens.
- I would like most of the camera's methods to return a `SignalGenerator` in order to be chainable. I'm not sure what the best way to do this would be, however.