### PR TITLE
feat: separate background by preview/rendering

### DIFF
--- a/packages/core/src/app/ProjectMetadata.ts
+++ b/packages/core/src/app/ProjectMetadata.ts
@@ -16,18 +16,19 @@ function createProjectMetadata(project: Project) {
   const meta = {
     version: new MetaField('version', 1),
     shared: new ObjectMetaField('General', {
-      background: new ColorMetaField('background', null),
       range: new RangeMetaField('range', [0, Infinity]),
       size: new Vector2MetaField('resolution', new Vector2(1920, 1080)),
       audioOffset: new NumberMetaField('audio offset', 0),
     }),
     preview: new ObjectMetaField('Preview', {
+      background: new ColorMetaField('background', null),
       fps: new NumberMetaField('frame rate', 30)
         .setPresets(FrameRates)
         .setRange(1),
       resolutionScale: new EnumMetaField('scale', Scales, 1),
     }),
     rendering: new ObjectMetaField('Rendering', {
+      background: new ColorMetaField('background', null),
       fps: new NumberMetaField('frame rate', 60)
         .setPresets(FrameRates)
         .setRange(1),

--- a/packages/core/src/app/bootstrap.ts
+++ b/packages/core/src/app/bootstrap.ts
@@ -41,7 +41,10 @@ export function bootstrap(
   } as Project;
 
   project.meta = new ProjectMetadata(project);
-  project.meta.shared.set(settings.defaults.get());
+  const {background, ...sharedDefaults} = settings.defaults.get();
+  project.meta.shared.set(sharedDefaults);
+  project.meta.preview.set({background});
+  project.meta.rendering.set({background});
   project.experimentalFeatures ??= false;
   metaFile.attach(project.meta);
 

--- a/packages/e2e/tests/project.meta
+++ b/packages/e2e/tests/project.meta
@@ -1,7 +1,6 @@
 {
   "version": 0,
   "shared": {
-    "background": "rgb(255,255,255)",
     "range": [
       0,
       null
@@ -13,10 +12,12 @@
     "audioOffset": 0
   },
   "preview": {
+    "background": "rgb(255,255,255)",
     "fps": 30,
     "resolutionScale": 1
   },
   "rendering": {
+    "background": "rgb(255,255,255)",
     "fps": 30,
     "resolutionScale": 1,
     "colorSpace": "srgb",

--- a/packages/template/src/project.meta
+++ b/packages/template/src/project.meta
@@ -1,7 +1,6 @@
 {
   "version": 1,
   "shared": {
-    "background": "rgb(20,20,20)",
     "range": [
       0,
       null
@@ -13,10 +12,12 @@
     "audioOffset": 0
   },
   "preview": {
+    "background": "rgb(20,20,20)",
     "fps": 60,
     "resolutionScale": 1
   },
   "rendering": {
+    "background": "rgb(20,20,20)",
     "fps": 30,
     "resolutionScale": 1,
     "colorSpace": "srgb",

--- a/packages/ui/src/components/viewport/PreviewStage.tsx
+++ b/packages/ui/src/components/viewport/PreviewStage.tsx
@@ -12,8 +12,8 @@ import {StageView} from './StageView';
 export function PreviewStage(props: JSX.HTMLAttributes<HTMLDivElement>) {
   const [stage] = useState(() => new Stage());
   const {player} = useApplication();
-  const {size, background} = useSharedSettings();
-  const {resolutionScale} = usePreviewSettings();
+  const {size} = useSharedSettings();
+  const {background, resolutionScale} = usePreviewSettings();
 
   useSubscribable(
     player.onRender,

--- a/packages/ui/src/components/viewport/StageView.tsx
+++ b/packages/ui/src/components/viewport/StageView.tsx
@@ -2,7 +2,7 @@ import type {Stage} from '@motion-canvas/core';
 import clsx from 'clsx';
 import {JSX} from 'preact';
 import {MutableRef, useLayoutEffect, useRef} from 'preact/hooks';
-import {useSharedSettings} from '../../hooks';
+import {usePreviewSettings} from '../../hooks';
 import styles from './Viewport.module.scss';
 
 export interface StageViewProps extends JSX.HTMLAttributes<HTMLDivElement> {
@@ -17,7 +17,7 @@ export function StageView({
   ...rest
 }: StageViewProps) {
   const localRef = useRef<HTMLDivElement>();
-  const {background} = useSharedSettings();
+  const {background} = usePreviewSettings();
   const ref = forwardRef ?? localRef;
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Closes: #1018 

Some issues:

- Currently the default setting for background will apply to both preview and rendering video settings - we could also introduce two separate settings (maybe best in a separate PR?)
- **Backwards Compatibility**: Background settings from existing projects will be dropped and set to null for both preview and render
- **Forwards Compatibility**: Background settings from newer projects read on older versions will not be recognized, and this will become null here as well
- I did not write any tests for this change, but happy to (the code I changed didn't appear to be covered originally)

To address backwards compatibility issues, one approach is to introduce some sort of a "deprecated" flag for old fields to hide them in the preview, and then set the preview & render backgrounds accordingly on initial project load. Happy to do this in a separate PR before merging this.

To address forwards compatibility issues, we could sync the deprecated background field above to one of the preview or render settings (not sure which is better). Although I'm not sure how concerned we are with forwards compatibility.

Let me know your thoughts @aarthificial 