### PR TITLE
docs: add hint about `?scene` import path to quickstart guide

### DIFF
--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -122,8 +122,8 @@ export default makeProject({
 ```
 
 When creating a project, we need to provide it with an array of scenes to
-display. In this case, we use only one scene imported from
-`src/scenes/example.tsx`.
+display. In this case, we use only one scene imported from `src/scenes/example.tsx?scene`. 
+(the `?scene` is required for TypeScript to recognize the file as a scene module.)
 
 A scene is a set of elements displayed on the screen and an animation that
 governs them. The most basic scene looks as follows:

--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -122,8 +122,13 @@ export default makeProject({
 ```
 
 When creating a project, we need to provide it with an array of scenes to
-display. In this case, we use only one scene imported from `src/scenes/example.tsx?scene`. 
-(the `?scene` is required for TypeScript to recognize the file as a scene module.)
+display. In this case, we use only one scene imported from
+`src/scenes/example.tsx?scene`.
+
+Note the `?scene` at the end - it's required to transform the imported module
+into a proper scene. Among other things, it makes it possible to dynamically
+refresh the preview whenever you modify the scene. The editor will not work
+without it.
 
 A scene is a set of elements displayed on the screen and an animation that
 governs them. The most basic scene looks as follows:


### PR DESCRIPTION
When I tried to render my project without the `?scene` import postfix I got the following errors.
I'd like to propose to add a hint about the import postfix to the quickstart guide. 

```ts import {makeProject} from '@motion-canvas/core';
import podcast from "./scenes/podcast/podcast"; // without ?scene

export default makeProject({
  scenes: [ podcast],
});
```


## Errors
![CleanShot 2024-06-30 at 15 17 11](https://github.com/motion-canvas/motion-canvas/assets/11938237/928c4d39-b860-4d6b-9799-bd43240f3bea)

![CleanShot 2024-06-30 at 15 17 39](https://github.com/motion-canvas/motion-canvas/assets/11938237/e134e7d7-b59d-4d48-9355-3f0222513cde)
