### PR TITLE
feat(ui): add modal actions

### DIFF
--- a/packages/ui/src/components/footer/Footer.module.scss
+++ b/packages/ui/src/components/footer/Footer.module.scss
@@ -19,6 +19,12 @@
   overflow: hidden;
 }
 
+.action {
+  color: var(--theme);
+  font-weight: bold;
+  margin-left: 4px;
+}
+
 .shortcut {
   display: flex;
 
@@ -34,7 +40,7 @@
     margin-right: 4px;
     padding: 0 4px;
   }
-  .action {
+  .description {
     white-space: nowrap;
   }
 }

--- a/packages/ui/src/components/footer/Footer.tsx
+++ b/packages/ui/src/components/footer/Footer.tsx
@@ -1,10 +1,11 @@
 import {useComputed} from '@preact/signals';
+import clsx from 'clsx';
 import {useShortcutContext} from '../../contexts/shortcuts';
 import styles from './Footer.module.scss';
 import {Versions} from './Versions';
 
 export function Footer() {
-  const {surface, configs} = useShortcutContext();
+  const {action, surface, configs} = useShortcutContext();
   const hints = useComputed(() => {
     const config = configs.current.get(surface.value);
     if (!config) return [];
@@ -14,10 +15,15 @@ export function Footer() {
   return (
     <div className={styles.root}>
       <div className={styles.shortcuts}>
+        {action.value && (
+          <div className={clsx(styles.shortcut, styles.action)}>
+            {action.value.name}
+          </div>
+        )}
         {hints.value.map(({display, description}) => (
           <div className={styles.shortcut}>
             <code className={styles.key}>{display}</code>
-            <span className={styles.action}>{description}</span>
+            <span className={styles.description}>{description}</span>
           </div>
         ))}
       </div>
@@ -25,3 +31,4 @@ export function Footer() {
     </div>
   );
 }
+('');


### PR DESCRIPTION
Shortcuts can now trigger modal actions:
1. The shortcut handler can return an action object to start it.
2. The action receives the following pointer events, blocking other shortcuts from being used.
3. Pressing the left or right mouse button completes or cancels the action respectively.