### PR TITLE
docs: proper link syntax to Spline from Path

### DIFF
--- a/packages/docs/docs/components/path.mdx
+++ b/packages/docs/docs/components/path.mdx
@@ -37,7 +37,7 @@ The `Path` node allows us to draw and animate SVG paths.
 `Path` nodes are great for displaying precalculated SVG paths, but the format
 can be confusing. If you want to have more intuitive control of the path, and
 control each point within Motion Canvas, we recommend checking out the
-[`Spline`](spline) component.
+[`Spline`](/api/2d/components/Spline) component.
 
 :::
 

--- a/packages/docs/docs/components/path.mdx
+++ b/packages/docs/docs/components/path.mdx
@@ -37,7 +37,7 @@ The `Path` node allows us to draw and animate SVG paths.
 `Path` nodes are great for displaying precalculated SVG paths, but the format
 can be confusing. If you want to have more intuitive control of the path, and
 control each point within Motion Canvas, we recommend checking out the
-[`Spline`][spline] component.
+[`Spline`](spline) component.
 
 :::
 


### PR DESCRIPTION
(Documentation) The "Path" page tried to link to "Spline", but it used invalid syntax `[display][link]` instead of `[display](link)`, resulting in a result that's broken visually and, more importantly, doesn't actually link. This simple commit fixes that.