### PR TITLE
fix(core): always show both scenes when seeking mid-transition

### DIFF
--- a/packages/core/src/app/PlaybackManager.ts
+++ b/packages/core/src/app/PlaybackManager.ts
@@ -224,7 +224,9 @@ export class PlaybackManager {
     let lastScene = this.scenes.current[0];
     for (const scene of this.scenes.current) {
       if (!scene.isCached() || scene.lastFrame > frame) {
-        return scene;
+        return frame > scene.firstFrame + scene.transitionDuration
+          ? scene
+          : lastScene;
       }
       lastScene = scene;
     }

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -56,6 +56,10 @@ export abstract class GeneratorScene<T>
     return this.cache.current.firstFrame;
   }
 
+  public get transitionDuration() {
+    return this.cache.current.transitionDuration;
+  }
+
   public get lastFrame() {
     return this.firstFrame + this.cache.current.duration;
   }

--- a/packages/core/src/scenes/Scene.ts
+++ b/packages/core/src/scenes/Scene.ts
@@ -161,6 +161,11 @@ export interface Scene<T = unknown> {
   get firstFrame(): number;
 
   /**
+   * Scene transition duration in frames.
+   */
+  get transitionDuration(): number;
+
+  /**
    * The frame at which this scene ends.
    */
   get lastFrame(): number;


### PR DESCRIPTION
This PR updates seeking-related logic in `PlaybackManager` to ensure both scenes are visible when seek position is in the middle of transition. Previously, it could occur that only the `currentScene` will be rendered, especially visible when seeking backwards.

Before:

https://github.com/user-attachments/assets/e83742a1-d3e5-4e3a-a848-f7d0e1b16d5b

After:

https://github.com/user-attachments/assets/9c834528-a812-46d2-891e-305d38f0ad56
