### PR TITLE
fix: lower the globalAlpha of the previous context as you increase th…

### DIFF
--- a/packages/core/src/transitions/fadeTransition.ts
+++ b/packages/core/src/transitions/fadeTransition.ts
@@ -11,6 +11,8 @@ export function* fadeTransition(duration = 0.6): ThreadGenerator {
   const progress = createSignal(0);
   const endTransition = useTransition(ctx => {
     ctx.globalAlpha = progress();
+  }, ctx => {
+    ctx.globalAlpha = 1 - progress();
   });
 
   yield* progress(1, duration);


### PR DESCRIPTION
…e current context

Previously, the fade transition caused the previous scene to suddenly vanish. This little tweak will cause the previous scene to gradually fade out while the current scene fades in.