### PR TITLE
Fix audio not playing when playhead is after audio's duration (not accounting for offset)

### DIFF
--- a/packages/core/src/media/AudioManager.ts
+++ b/packages/core/src/media/AudioManager.ts
@@ -58,7 +58,10 @@ export class AudioManager {
   }
 
   public isInRange(time: number) {
-    return time >= this.offset && time < this.audioElement.duration;
+    const audioRangeStart = this.offset;
+    const audioRangeEnd = this.audioElement.duration + this.offset;
+
+    return audioRangeStart <= time && time <= audioRangeEnd;
   }
 
   public toRelativeTime(time: number) {


### PR DESCRIPTION
Fixes #1155 

When preparing to play, the player checks whether the audio should be playing by following this logic:

https://github.com/motion-canvas/motion-canvas/blob/13c9de85280cc1b893a178b9d6eecd8d639fd7bb/packages/core/src/app/Player.ts#L412-L413

One of the things it checks is whether the current time is in the audio's range.

When we look at `AudioManager.isInRange`'s implementation:

https://github.com/motion-canvas/motion-canvas/blob/main/packages/core/src/media/AudioManager.ts#L60-L62

we notice that it doesn't account for the audio offset, which causes the issue.
