### PR TITLE
Validate resolution field (coerce values in UI so it remains within bounds)

### DIFF
--- a/packages/core/src/app/ProjectMetadata.ts
+++ b/packages/core/src/app/ProjectMetadata.ts
@@ -18,7 +18,9 @@ function createProjectMetadata(project: Project) {
     shared: new ObjectMetaField('General', {
       background: new ColorMetaField('background', null),
       range: new RangeMetaField('range', [0, Infinity]),
-      size: new Vector2MetaField('resolution', new Vector2(1920, 1080)),
+      size: new Vector2MetaField('resolution', new Vector2(1920, 1080), {
+        min: [1, 1],
+      }),
       audioOffset: new NumberMetaField('audio offset', 0),
     }),
     preview: new ObjectMetaField('Preview', {

--- a/packages/core/src/app/ProjectMetadata.ts
+++ b/packages/core/src/app/ProjectMetadata.ts
@@ -18,9 +18,9 @@ function createProjectMetadata(project: Project) {
     shared: new ObjectMetaField('General', {
       background: new ColorMetaField('background', null),
       range: new RangeMetaField('range', [0, Infinity]),
-      size: new Vector2MetaField('resolution', new Vector2(1920, 1080), {
-        min: [1, 1],
-      }),
+      size: new Vector2MetaField('resolution', new Vector2(1920, 1080)).min([
+        1, 1,
+      ]),
       audioOffset: new NumberMetaField('audio offset', 0),
     }),
     preview: new ObjectMetaField('Preview', {

--- a/packages/core/src/meta/Vector2MetaField.test.ts
+++ b/packages/core/src/meta/Vector2MetaField.test.ts
@@ -1,80 +1,58 @@
 import {describe, expect, it} from 'vitest';
 import {Vector2} from '../types';
-import {
-  Vector2MetaField,
-  Vector2MetaFieldConstructorParameters,
-} from './Vector2MetaField';
+import {Vector2MetaField} from './Vector2MetaField';
 
 describe('Vector2MetaField', () => {
-  describe('Enforces invariants', () => {
-    it('Throws error when constructing where some element of the vector is out of bounds', () => {
+  describe('Parses correctly', () => {
+    it('Coerces vector values according to bounds when updating values', () => {
       const min: [number, number] = [10, 20];
       const max: [number, number] = [1000, 2000] as const;
       const name = 'Some name';
-      const parameters: Vector2MetaFieldConstructorParameters = {
-        min,
-        max,
-      };
+      const initial = new Vector2(12, 22);
+      const prototype = new Vector2MetaField(name, initial).min(min).max(max);
 
-      // Lower bound violation
-      expect(
-        () => new Vector2MetaField(name, new Vector2([9, 22]), parameters),
-      ).toThrow();
-      expect(
-        () => new Vector2MetaField(name, new Vector2([20, 19]), parameters),
-      ).toThrow();
+      // Lower bound coercion
+      const field1 = prototype.clone();
+      field1.set([9, 22]);
+      expect(field1.get().toArray()).toStrictEqual([10, 22]);
 
-      // Upper bound violation
-      expect(
-        () => new Vector2MetaField(name, new Vector2([1200, 22]), parameters),
-      ).toThrow();
-      expect(
-        () => new Vector2MetaField(name, new Vector2([500, 2200]), parameters),
-      ).toThrow();
+      const field2 = prototype.clone();
+      field2.set([20, 19]);
+      expect(field2.get().toArray()).toStrictEqual([20, 20]);
+
+      // Upper bound coercion
+      const field3 = prototype.clone();
+      field3.set([1200, 22]);
+      expect(field3.get().toArray()).toStrictEqual([1000, 22]);
+
+      const field4 = prototype.clone();
+      field4.set([500, 2200]);
+      expect(field4.get().toArray()).toStrictEqual([500, 2000]);
     });
 
-    it('Throws error when setting value where some element of the vector is out of bounds', () => {
-      const min: [number, number] = [10, 20];
-      const max: [number, number] = [1000, 2000] as const;
+    it('Coerces vector values according to bounds when updating bounds', () => {
       const name = 'Some name';
-      const parameters: Vector2MetaFieldConstructorParameters = {
-        min,
-        max,
-      };
+      const initial = new Vector2(12, 22);
+      const prototype = new Vector2MetaField(name, initial);
 
-      const field = new Vector2MetaField(
-        name,
-        new Vector2([100, 200]),
-        parameters,
-      );
+      // Lower bound coercion
+      const field1 = prototype.clone();
+      field1.min([20, 30]);
+      expect(field1.get().toArray()).toStrictEqual([20, 30]);
 
-      // Lower bound violation
-      expect(() => field.set(new Vector2([9, 22]))).toThrow();
-      expect(() => field.set(new Vector2([20, 19]))).toThrow();
-
-      // Upper bound violation
-      expect(() => field.set(new Vector2([1200, 22]))).toThrow();
-      expect(() => field.set(new Vector2([500, 2200]))).toThrow();
+      // Upper bound coercion
+      const field2 = prototype.clone();
+      field2.max([10, 20]);
+      expect(field2.get().toArray()).toStrictEqual([10, 20]);
     });
 
-    it('Throws error when bounds parameters cross', () => {
+    it('Throws error when bounds cross', () => {
       const name = 'Some name';
       const initial = new Vector2(1, 2);
+      const field = new Vector2MetaField(name, initial);
 
-      expect(
-        () =>
-          new Vector2MetaField(name, initial, {
-            min: [10, 20],
-            max: [9, 30],
-          }),
-      ).toThrow();
-      expect(
-        () =>
-          new Vector2MetaField(name, initial, {
-            min: [10, 20],
-            max: [200, -10],
-          }),
-      ).toThrow();
+      expect(() => field.min([10, 20]).max([9, 30])).toThrow();
+      expect(() => field.min([10, 20]).max([200, -10])).toThrow();
     });
   });
 });

--- a/packages/core/src/meta/Vector2MetaField.test.ts
+++ b/packages/core/src/meta/Vector2MetaField.test.ts
@@ -1,0 +1,80 @@
+import {describe, expect, it} from 'vitest';
+import {Vector2} from '../types';
+import {
+  Vector2MetaField,
+  Vector2MetaFieldConstructorParameters,
+} from './Vector2MetaField';
+
+describe('Vector2MetaField', () => {
+  describe('Enforces invariants', () => {
+    it('Throws error when constructing where some element of the vector is out of bounds', () => {
+      const min: [number, number] = [10, 20];
+      const max: [number, number] = [1000, 2000] as const;
+      const name = 'Some name';
+      const parameters: Vector2MetaFieldConstructorParameters = {
+        min,
+        max,
+      };
+
+      // Lower bound violation
+      expect(
+        () => new Vector2MetaField(name, new Vector2([9, 22]), parameters),
+      ).toThrow();
+      expect(
+        () => new Vector2MetaField(name, new Vector2([20, 19]), parameters),
+      ).toThrow();
+
+      // Upper bound violation
+      expect(
+        () => new Vector2MetaField(name, new Vector2([1200, 22]), parameters),
+      ).toThrow();
+      expect(
+        () => new Vector2MetaField(name, new Vector2([500, 2200]), parameters),
+      ).toThrow();
+    });
+
+    it('Throws error when setting value where some element of the vector is out of bounds', () => {
+      const min: [number, number] = [10, 20];
+      const max: [number, number] = [1000, 2000] as const;
+      const name = 'Some name';
+      const parameters: Vector2MetaFieldConstructorParameters = {
+        min,
+        max,
+      };
+
+      const field = new Vector2MetaField(
+        name,
+        new Vector2([100, 200]),
+        parameters,
+      );
+
+      // Lower bound violation
+      expect(() => field.set(new Vector2([9, 22]))).toThrow();
+      expect(() => field.set(new Vector2([20, 19]))).toThrow();
+
+      // Upper bound violation
+      expect(() => field.set(new Vector2([1200, 22]))).toThrow();
+      expect(() => field.set(new Vector2([500, 2200]))).toThrow();
+    });
+
+    it('Throws error when bounds parameters cross', () => {
+      const name = 'Some name';
+      const initial = new Vector2(1, 2);
+
+      expect(
+        () =>
+          new Vector2MetaField(name, initial, {
+            min: [10, 20],
+            max: [9, 30],
+          }),
+      ).toThrow();
+      expect(
+        () =>
+          new Vector2MetaField(name, initial, {
+            min: [10, 20],
+            max: [200, -10],
+          }),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/core/src/meta/Vector2MetaField.ts
+++ b/packages/core/src/meta/Vector2MetaField.ts
@@ -1,33 +1,6 @@
+import {clamp} from '../tweening';
 import {PossibleVector2, Vector2} from '../types';
 import {MetaField} from './MetaField';
-
-export type Vector2MetaFieldConstructorParameters = {
-  /**
-   * A 2D tuple representing the minimum value
-   * (inclusive) for each element of the the vector.
-   *
-   * Defaults to [-Infinity, -Infinity].
-   *
-   * This constitutes an invariant of the vector
-   * and attempts to change its value will be
-   * validated against it, which will trigger
-   * an exception if validation fails.
-   */
-  min?: [number, number];
-
-  /**
-   * A 2D tuple representing the maximum value
-   * (inclusive) for each element of the the vector.
-   *
-   * Defaults to [Infinity, Infinity].
-   *
-   * This constitutes an invariant of the vector
-   * and attempts to change its value will be
-   * validated against it, which will trigger
-   * an exception if validation fails.
-   */
-  max?: [number, number];
-};
 
 /**
  * Represents a two-dimensional vector stored in a meta file.
@@ -35,35 +8,94 @@ export type Vector2MetaFieldConstructorParameters = {
 export class Vector2MetaField extends MetaField<PossibleVector2, Vector2> {
   public readonly type = Vector2.symbol;
 
-  public readonly min;
-  public readonly max;
-
   public constructor(
-    name: string,
-    initial: Vector2,
-    {max: argMax, min: argMin}: Vector2MetaFieldConstructorParameters = {},
+    public readonly name: string,
+    public readonly initial: Vector2,
   ) {
-    const min = argMin ?? [-Infinity, -Infinity];
-    const max = argMax ?? [Infinity, Infinity];
-
-    Vector2MetaField.validateBoundsParameters(min, max);
-
-    Vector2MetaField.validateAgainstBounds(min, max, initial);
-
     super(name, initial);
 
-    this.min = min;
-    this.max = max;
+    this.lowerBounds = [-Infinity, -Infinity];
+    this.upperBounds = [Infinity, Infinity];
   }
 
   public override parse(value: PossibleVector2): Vector2 {
-    Vector2MetaField.validateAgainstBounds(this.min, this.max, value);
-
-    return new Vector2(value);
+    return Vector2MetaField.coerceAgainstBounds(
+      this.lowerBounds,
+      this.upperBounds,
+      value,
+    );
   }
 
   public override serialize(): PossibleVector2 {
     return this.value.current.serialize();
+  }
+
+  public min(lowerBounds: [number, number]): Vector2MetaField {
+    Vector2MetaField.validateBoundsParameters(lowerBounds, this.upperBounds);
+
+    this.lowerBounds = lowerBounds;
+
+    // When changing the upper bounds
+    // we need to re-set the value
+    // so that it conforms to the updated bounds
+    this.set(
+      Vector2MetaField.coerceAgainstBounds(
+        this.lowerBounds,
+        this.upperBounds,
+        this.get(),
+      ),
+    );
+
+    return this;
+  }
+
+  public max(upperBounds: [number, number]): Vector2MetaField {
+    Vector2MetaField.validateBoundsParameters(this.lowerBounds, upperBounds);
+
+    this.upperBounds = upperBounds;
+
+    // When changing the upper bounds
+    // we need to re-set the value
+    // so that it conforms to the updated bounds
+    this.set(
+      Vector2MetaField.coerceAgainstBounds(
+        this.lowerBounds,
+        this.upperBounds,
+        this.get(),
+      ),
+    );
+
+    return this;
+  }
+
+  /**
+   * A 2D tuple representing the minimum value
+   * (inclusive) for each element of the the vector.
+   *
+   * Defaults to [-Infinity, -Infinity].
+   */
+  public getMin(): [number, number] {
+    return this.lowerBounds;
+  }
+
+  /**
+   * A 2D tuple representing the maximum value
+   * (inclusive) for each element of the the vector.
+   *
+   * Defaults to [Infinity, Infinity].
+   */
+  public getMax(): [number, number] {
+    return this.upperBounds;
+  }
+
+  public override clone(): this {
+    const vectorClone = new Vector2(this.get().x, this.get().y);
+
+    // I'm not entirely sure what's going on here type-wise
+    // that it complains about the return type
+    return new Vector2MetaField(this.name, vectorClone)
+      .min(this.getMin())
+      .max(this.getMax()) as MetaField<PossibleVector2, Vector2> as any;
   }
 
   private static validateBoundsParameters(
@@ -85,27 +117,27 @@ export class Vector2MetaField extends MetaField<PossibleVector2, Vector2> {
     }
   }
 
-  private static validateAgainstBounds(
+  private static coerceAgainstBounds(
     min: [number, number],
     max: [number, number],
     value: PossibleVector2,
-  ): void {
+  ): Vector2 {
     const vector = new Vector2(value);
 
     const [minX, minY] = min;
     const [maxX, maxY] = max;
-    const [x, y] = [vector.x, vector.y];
+    const [originalX, originalY] = [vector.x, vector.y];
 
-    if (x < minX || y < minY || x > maxX || y > maxY) {
-      const message = [
-        `Vector2MetaField invariant violation!`,
-        `You're trying to construct/set this field to a value that is out of bounds!`,
-        `Value -> [${x}, ${y}]`,
-        `Min -> [${minX}, ${minY}]`,
-        `Max -> [${maxX}, ${maxY}]`,
-      ].join('\n');
+    const coercedX = clamp(minX, maxX, originalX);
+    const coercedY = clamp(minY, maxY, originalY);
 
-      throw new Error(message);
-    }
+    vector.x = coercedX;
+    vector.y = coercedY;
+
+    return vector;
   }
+
+  private lowerBounds: [number, number];
+
+  private upperBounds: [number, number];
 }

--- a/packages/core/src/meta/Vector2MetaField.ts
+++ b/packages/core/src/meta/Vector2MetaField.ts
@@ -1,17 +1,111 @@
 import {PossibleVector2, Vector2} from '../types';
 import {MetaField} from './MetaField';
 
+export type Vector2MetaFieldConstructorParameters = {
+  /**
+   * A 2D tuple representing the minimum value
+   * (inclusive) for each element of the the vector.
+   *
+   * Defaults to [-Infinity, -Infinity].
+   *
+   * This constitutes an invariant of the vector
+   * and attempts to change its value will be
+   * validated against it, which will trigger
+   * an exception if validation fails.
+   */
+  min?: [number, number];
+
+  /**
+   * A 2D tuple representing the maximum value
+   * (inclusive) for each element of the the vector.
+   *
+   * Defaults to [Infinity, Infinity].
+   *
+   * This constitutes an invariant of the vector
+   * and attempts to change its value will be
+   * validated against it, which will trigger
+   * an exception if validation fails.
+   */
+  max?: [number, number];
+};
+
 /**
  * Represents a two-dimensional vector stored in a meta file.
  */
 export class Vector2MetaField extends MetaField<PossibleVector2, Vector2> {
   public readonly type = Vector2.symbol;
 
+  public readonly min;
+  public readonly max;
+
+  public constructor(
+    name: string,
+    initial: Vector2,
+    {max: argMax, min: argMin}: Vector2MetaFieldConstructorParameters = {},
+  ) {
+    const min = argMin ?? [-Infinity, -Infinity];
+    const max = argMax ?? [Infinity, Infinity];
+
+    Vector2MetaField.validateBoundsParameters(min, max);
+
+    Vector2MetaField.validateAgainstBounds(min, max, initial);
+
+    super(name, initial);
+
+    this.min = min;
+    this.max = max;
+  }
+
   public override parse(value: PossibleVector2): Vector2 {
+    Vector2MetaField.validateAgainstBounds(this.min, this.max, value);
+
     return new Vector2(value);
   }
 
   public override serialize(): PossibleVector2 {
     return this.value.current.serialize();
+  }
+
+  private static validateBoundsParameters(
+    min: [number, number],
+    max: [number, number],
+  ): void {
+    const [minX, minY] = min;
+    const [maxX, maxY] = max;
+
+    if (minX > maxX || minY > maxY) {
+      const message = [
+        `Vector2MetaField invariant violation!`,
+        `Vector bounds (min and max) must not cross!`,
+        `Min -> [${minX}, ${minY}]`,
+        `Max -> [${maxX}, ${maxY}]`,
+      ].join('\n');
+
+      throw new Error(message);
+    }
+  }
+
+  private static validateAgainstBounds(
+    min: [number, number],
+    max: [number, number],
+    value: PossibleVector2,
+  ): void {
+    const vector = new Vector2(value);
+
+    const [minX, minY] = min;
+    const [maxX, maxY] = max;
+    const [x, y] = [vector.x, vector.y];
+
+    if (x < minX || y < minY || x > maxX || y > maxY) {
+      const message = [
+        `Vector2MetaField invariant violation!`,
+        `You're trying to construct/set this field to a value that is out of bounds!`,
+        `Value -> [${x}, ${y}]`,
+        `Min -> [${minX}, ${minY}]`,
+        `Max -> [${maxX}, ${maxY}]`,
+      ].join('\n');
+
+      throw new Error(message);
+    }
   }
 }

--- a/packages/ui/src/components/meta/MetaFieldView.tsx
+++ b/packages/ui/src/components/meta/MetaFieldView.tsx
@@ -39,8 +39,6 @@ export function MetaFieldView({field}: MetaFieldViewProps) {
   const Field: FiledView = TYPE_MAP.get(field.type) ?? UnknownMetaFieldView;
   const disabled = useSubscribableValue(field.onDisabled);
 
-  console.log(field);
-
   return disabled ? (
     <></>
   ) : (

--- a/packages/ui/src/components/meta/MetaFieldView.tsx
+++ b/packages/ui/src/components/meta/MetaFieldView.tsx
@@ -39,6 +39,8 @@ export function MetaFieldView({field}: MetaFieldViewProps) {
   const Field: FiledView = TYPE_MAP.get(field.type) ?? UnknownMetaFieldView;
   const disabled = useSubscribableValue(field.onDisabled);
 
+  console.log(field);
+
   return disabled ? (
     <></>
   ) : (

--- a/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
+++ b/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
@@ -1,6 +1,5 @@
 import {Vector2MetaField} from '@motion-canvas/core';
 import {useSubscribableValue} from '../../hooks';
-import {clamp} from '../../utils';
 import {NumberInput} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';
 
@@ -11,8 +10,8 @@ export interface Vector2MetaFieldViewProps {
 export function Vector2MetaFieldView({field}: Vector2MetaFieldViewProps) {
   const value = useSubscribableValue(field.onChanged);
 
-  const [minX, minY] = field.min;
-  const [maxX, maxY] = field.max;
+  const [minX, minY] = field.getMin();
+  const [maxX, maxY] = field.getMax();
 
   const onXChanged = (x: number) => {
     if (isNaN(x)) {
@@ -21,9 +20,7 @@ export function Vector2MetaFieldView({field}: Vector2MetaFieldViewProps) {
       return;
     }
 
-    const newX = clamp(minX, maxX, x);
-
-    field.set([newX, value.y]);
+    field.set([x, value.y]);
   };
 
   const onYChanged = (y: number) => {
@@ -33,9 +30,7 @@ export function Vector2MetaFieldView({field}: Vector2MetaFieldViewProps) {
       return;
     }
 
-    const newY = clamp(minY, maxY, y);
-
-    field.set([value.x, newY]);
+    field.set([value.x, y]);
   };
 
   return (

--- a/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
+++ b/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
@@ -1,5 +1,6 @@
 import {Vector2MetaField} from '@motion-canvas/core';
 import {useSubscribableValue} from '../../hooks';
+import {clamp} from '../../utils';
 import {NumberInput} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';
 
@@ -10,10 +11,47 @@ export interface Vector2MetaFieldViewProps {
 export function Vector2MetaFieldView({field}: Vector2MetaFieldViewProps) {
   const value = useSubscribableValue(field.onChanged);
 
+  const [minX, minY] = field.min;
+  const [maxX, maxY] = field.max;
+
+  const onXChanged = (x: number) => {
+    if (isNaN(x)) {
+      // No op when NaN is passed
+      field.set(value);
+      return;
+    }
+
+    const newX = clamp(minX, maxX, x);
+
+    field.set([newX, value.y]);
+  };
+
+  const onYChanged = (y: number) => {
+    if (isNaN(y)) {
+      // No op when NaN is passed
+      field.set(value);
+      return;
+    }
+
+    const newY = clamp(minY, maxY, y);
+
+    field.set([value.x, newY]);
+  };
+
   return (
     <MetaFieldGroup field={field}>
-      <NumberInput value={value.x} onChange={x => field.set([x, value.y])} />
-      <NumberInput value={value.y} onChange={y => field.set([value.x, y])} />
+      <NumberInput
+        min={minX}
+        max={maxX}
+        value={value.x}
+        onChange={onXChanged}
+      />
+      <NumberInput
+        min={minY}
+        max={maxY}
+        value={value.y}
+        onChange={onYChanged}
+      />
     </MetaFieldGroup>
   );
 }


### PR DESCRIPTION
Fixes #1149 .

## Demo

![motion-canvas](https://github.com/user-attachments/assets/b9cf9bf8-27ce-4f51-a4b1-ac293862de31)

## Overview

Implements coercion for the resolution fields so that inputted values always remain within bounds (i.e. non-zero positive value).

I implemented a strategy which I think makes the most sense UX-wise, which is:

- When the inputted value is outside bounds, it gets clamped
- When the inputted value is not a number, it remains unaltered

To accomplish that, I:

- Implemented the possibility to pass bounds (lower and upper) to `Vector2MetaField` which constitutes its invariants and are checked as its constructor and mutating methods preconditions
- Made it so that `Vector2MetaFieldView` automatically reads these bounds and coerces inputted values 