### PR TITLE
Add documentation for option out of layout with layout={false} and fix Signal Overview example

### DIFF
--- a/packages/docs/docs/getting-started/layouts.mdx
+++ b/packages/docs/docs/getting-started/layouts.mdx
@@ -72,7 +72,7 @@ class has additional `size` and `offset` properties:
 
 ## Opting out of layout 
 
-You can disable the layout behaviour by passing `layout={false}` to your component:
+You can disable layout behavior by passing `layout={false}` to your component:
 
 ```tsx
 <Layout layout direction="row">
@@ -97,12 +97,28 @@ This behaves like absolute postioning in CSS Flexbox:
 }
 ```
 
-### `Layout.layout`
-
-<ApiSnippet url={'/api/2d/components/Layout#layout'} />
-<hr/>
-
 You can learn more about layout exceptions in the [Groups](#groups) section below.
+
+## Groups
+
+Nodes that don't extend the `Layout` class, such as the `Node` itself, are
+unaffected by the layout and are treated as if they were never there. This lets
+you apply filters and transformations to layout nodes without affecting the
+hierarchy.
+
+From the layout's perspective, all `<Rect>`s in the example below are siblings:
+
+```tsx
+<Layout direction={'column'} width={960} gap={40} layout>
+  <Node opacity={0.1}>
+    <Rect height={240} fill={'#ff6470'} />
+    <Rect height={240} fill={'#ff6470'} />
+  </Node>
+  <Rect height={240} fill={'#ff6470'} />
+</Layout>
+```
+
+<AnimationPlayer name="layout-group" small />
 
 ## Cardinal directions
 
@@ -194,26 +210,5 @@ useful properties are listed below:
 
 <ApiSnippet url={'/api/2d/components/Layout#justifyContent'} />
 <hr />
-
-## Groups
-
-Nodes that don't extend the `Layout` class, such as the `Node` itself, are
-unaffected by the layout and are treated as if they were never there. This lets
-you apply filters and transformations to layout nodes without affecting the
-hierarchy.
-
-From the layout's perspective, all `<Rect>`s in the example below are siblings:
-
-```tsx
-<Layout direction={'column'} width={960} gap={40} layout>
-  <Node opacity={0.1}>
-    <Rect height={240} fill={'#ff6470'} />
-    <Rect height={240} fill={'#ff6470'} />
-  </Node>
-  <Rect height={240} fill={'#ff6470'} />
-</Layout>
-```
-
-<AnimationPlayer name="layout-group" small />
 
 [flexbox]: https://css-tricks.com/snippets/css/a-guide-to-flexbox/

--- a/packages/docs/docs/getting-started/layouts.mdx
+++ b/packages/docs/docs/getting-started/layouts.mdx
@@ -70,6 +70,33 @@ class has additional `size` and `offset` properties:
 <ApiSnippet url={'/api/2d/components/Layout#offset'} />
 <hr />
 
+## Opting Out of Layout 
+
+You can disable the layout behaviour by passing `layout={false}` to your component:
+
+```tsx
+<Layout layout direction="row">
+  <Rect width={100} height={100} fill="green"/>
+  <Rect width={100} height={100} fill="red" layout={false} x={200} y={50}/>
+</Layout>
+```
+
+This behaves almost similar to **absolute postioning** in CSS Flexbox: 
+- The node doesn't affect or get affected by layout flow
+- You're responsible for positioning it manually
+- It can still be visually inside a layout container
+
+```css
+.parent{
+  display:flex;
+}
+
+.child{
+  position: absolute;
+}
+```
+
+You can learn more about such layout exceptions in the [Groups](#groups) section below.
 ## Cardinal directions
 
 Layout nodes come with a set of helper properties that let you position them in

--- a/packages/docs/docs/getting-started/layouts.mdx
+++ b/packages/docs/docs/getting-started/layouts.mdx
@@ -70,7 +70,7 @@ class has additional `size` and `offset` properties:
 <ApiSnippet url={'/api/2d/components/Layout#offset'} />
 <hr />
 
-## Opting Out of Layout 
+## Opting out of layout 
 
 You can disable the layout behaviour by passing `layout={false}` to your component:
 
@@ -81,22 +81,29 @@ You can disable the layout behaviour by passing `layout={false}` to your compone
 </Layout>
 ```
 
-This behaves almost similar to **absolute postioning** in CSS Flexbox: 
+This behaves like absolute postioning in CSS Flexbox: 
 - The node doesn't affect or get affected by layout flow
+- The node doesn't lay out its own children
 - You're responsible for positioning it manually
 - It can still be visually inside a layout container
 
 ```css
-.parent{
-  display:flex;
+.parent {
+  display: flex;
 }
 
-.child{
+.child {
   position: absolute;
 }
 ```
 
-You can learn more about such layout exceptions in the [Groups](#groups) section below.
+### `Layout.layout`
+
+<ApiSnippet url={'/api/2d/components/Layout#layout'} />
+<hr/>
+
+You can learn more about layout exceptions in the [Groups](#groups) section below.
+
 ## Cardinal directions
 
 Layout nodes come with a set of helper properties that let you position them in

--- a/packages/docs/docs/getting-started/signals.mdx
+++ b/packages/docs/docs/getting-started/signals.mdx
@@ -51,11 +51,11 @@ actions (The action is chosen based on the number of arguments):
    ```
 2. update the value:
    ```ts
-   signal(3);
+   value(3);
    ```
 3. create a [tween](/docs/tweening) for the value:
    ```ts
-   yield * signal(2, 0.3);
+   yield * value(2, 0.3);
    ```
 
 Instead of the actual value, a signal can be provided with a function that


### PR DESCRIPTION
### What’s Changed

- Added a section explaining how to disable layout behavior using `layout={false}`
- Compared it to CSS `position: absolute` behavior for clarity
- Linked to the Groups section for further reference
- Updated Signal Overview 

### Why?

This helps clarify how layout opt-out works in motion-canvas, especially for users coming from a CSS/Flexbox background.

---
Closes #449 Closes #1183
Let me know if this should be rephrased or if anything more needs to be added.