### PR TITLE
fix(ffmpeg): chain promises to keep frame order

### DIFF
--- a/packages/ffmpeg/client/FFmpegExporterClient.ts
+++ b/packages/ffmpeg/client/FFmpegExporterClient.ts
@@ -32,9 +32,6 @@ type FFmpegExporterOptions = ValueOf<
 
 type InvokeStrategy = 'ws' | 'octet-stream';
 
-const EXPORT_FRAME_LIMIT = 256;
-const EXPORT_RETRY_DELAY = 1000;
-
 /**
  * FFmpeg video exporter.
  *
@@ -82,6 +79,7 @@ export class FFmpegExporterClient implements Exporter {
     }
   }
 
+  private currentFramePromise: Promise<void> = Promise.resolve();
   private concurrentFrames = 0;
   private error: unknown = false;
 
@@ -111,30 +109,34 @@ export class FFmpegExporterClient implements Exporter {
     _signal: AbortSignal,
     context: CanvasRenderingContext2D,
   ): Promise<void> {
-    while (this.concurrentFrames >= EXPORT_FRAME_LIMIT) {
-      await new Promise(resolve => setTimeout(resolve, EXPORT_RETRY_DELAY));
-    }
-
-    if (this.error) {
-      throw this.error;
-    }
-
     const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
-    this.concurrentFrames++;
-    this.invoke('handleFrame', data, 'octet-stream')
-      .then(() => {
-        this.concurrentFrames--;
-      })
-      .catch(error => {
+
+    const previousFramePromise = this.currentFramePromise;
+
+    const framePromise = (async () => {
+      await previousFramePromise; // Wait for the previous frame to finish
+      if (this.error) {
+        throw this.error; // If an error has occurred, throw it
+      }
+      try {
+        this.concurrentFrames++;
+        await this.invoke('handleFrame', data, 'octet-stream');
+      } catch (error) {
         this.error = error;
+        throw error;
+      } finally {
         this.concurrentFrames--;
-      });
+      }
+    })();
+
+    this.currentFramePromise = framePromise;
+    return framePromise;
   }
 
   public async stop(result: RendererResult): Promise<void> {
-    while (this.concurrentFrames >= EXPORT_FRAME_LIMIT) {
-      await new Promise(resolve => setTimeout(resolve, EXPORT_RETRY_DELAY));
-    }
+    await this.currentFramePromise;
+
+    this.currentFramePromise = Promise.resolve();
 
     if (this.error) {
       throw this.error;


### PR DESCRIPTION
I encountered strange issues with the FFmpeg export: the export did not contain all frames. See #1204

To me, it looks like the final 'end' message to close the ImageStream is transmitted before other frames (perhaps due to its smaller size).
Further, looking at the FFmpegExporterClient.ts implementation, I also fear that frames could be delivered out of order. This especially holds when the EXPORT_FRAME_LIMIT is reached: as long as the limit is not reached, frames should be transmitted in order, as the transmission is typically over the local network and the frames are the same size (though there is no guarantee). However, once a frame waits because of the EXPORT_RETRY_DELAY, a later frame might just be sent before an earlier frame, making out-of-order transmissions much more likely. Please correct me if I am wrong.

To tackle these issues, I propose to (1) let the end message wait for all frames to be transmitted and (2) let frames wait for the previous frames to be transmitted.

I achieved both by keeping track of the promise for the current frame. A new frame replaces this promise while awaiting the previous promise. Finally, the end message is only sent after the current frame (which will then be the final frame) has been transmitted. Hence, frames are guaranteed to be in order, but at the same time, frames are no longer transmitted concurrently, resulting in a slowed-down export. A reliable concurrent export should include the frame indices, which the server can then use to reorder the frames.

 