### PR TITLE
fix(2d): support nested svg elements

### DIFF
--- a/packages/2d/src/lib/components/SVG.ts
+++ b/packages/2d/src/lib/components/SVG.ts
@@ -783,6 +783,34 @@ export class SVG extends Shape {
           ...SVG.getMatrixTransformation(transformation),
         } as ImgProps,
       };
+    } else if (child.tagName === 'svg') {
+      // Handle nested <svg> elements (used by MathJax for stretchy brackets
+      // in cases/matrix environments). These have their own coordinate system
+      // defined by viewBox that we need to account for.
+      const nestedSvg = child as unknown as SVGSVGElement;
+      let nestedTransform = transformMatrix;
+
+      // Apply viewBox transformation if present
+      if (nestedSvg.hasAttribute('viewBox')) {
+        try {
+          const vb = nestedSvg.viewBox.baseVal;
+          const width = SVG.parseNumberAttribute(child, 'width') || vb.width;
+          const height = SVG.parseNumberAttribute(child, 'height') || vb.height;
+
+          // Calculate scale from viewBox to actual size
+          const scaleX = width / vb.width;
+          const scaleY = height / vb.height;
+
+          // Apply viewBox origin offset and scale
+          nestedTransform = nestedTransform
+            .scaleSelf(scaleX, scaleY)
+            .translateSelf(-vb.x, -vb.y);
+        } catch {
+          // viewBox parsing failed, continue with basic transform
+        }
+      }
+
+      yield* SVG.extractGroupNodes(child, svgRoot, nestedTransform, style);
     }
   }
 }


### PR DESCRIPTION
Adds support for nested svg components used by MathJax for example.

See discord: https://discord.com/channels/1071029581009657896/1467105327802748959/1467105327802748959


Before:
<img width="342" height="307" alt="image" src="https://github.com/user-attachments/assets/560ebc12-c5f7-4d05-a8b5-7d6b65ed8619" />


After:
<img width="502" height="431" alt="image" src="https://github.com/user-attachments/assets/4c061e9b-7029-4dd5-8907-0273992137c5" />
