### PR TITLE
Add 3x, 3.5x, and 4x playback speed options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+
+### Bug Fixes
+
+* **core:** fix incorrect rollup ordering ([4743b92](https://github.com/motion-canvas/motion-canvas/commit/4743b92d10eed301b473434cc5cdde27882607bb))
+* **vite-plugin, ui:** project file path on selection ([#1090](https://github.com/motion-canvas/motion-canvas/issues/1090)) ([f15b375](https://github.com/motion-canvas/motion-canvas/commit/f15b3753d47bcca8cd2d3f213f5624cf5e54142d))
+
+
+
+
+
 ## [3.17.1](https://github.com/motion-canvas/motion-canvas/compare/v3.17.0...v3.17.1) (2024-08-17)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "private": false,
-  "version": "3.17.1",
+  "version": "3.17.2",
   "ignoreChanges": ["**/*.test.ts", "**/*.md"],
   "message": "ci(release): %v [skip ci]",
   "conventionalCommits": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25954,20 +25954,20 @@
     },
     "packages/2d": {
       "name": "@motion-canvas/2d",
-      "version": "3.17.1",
+      "version": "3.17.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.10.1",
         "@lezer/common": "^1.2.1",
         "@lezer/highlight": "^1.2.0",
-        "@motion-canvas/core": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
         "code-fns": "^0.8.2",
         "mathjax-full": "^3.2.2",
         "parse-svg-path": "^0.1.2"
       },
       "devDependencies": {
         "@motion-canvas/internal": "0.0.0",
-        "@motion-canvas/ui": "^3.17.0",
+        "@motion-canvas/ui": "^3.17.2",
         "@preact/signals": "^1.2.1",
         "clsx": "^2.0.0",
         "jsdom": "^22.1.0",
@@ -25994,7 +25994,7 @@
     },
     "packages/core": {
       "name": "@motion-canvas/core",
-      "version": "3.17.0",
+      "version": "3.17.2",
       "license": "MIT",
       "dependencies": {
         "@types/chroma-js": "2.4.4",
@@ -26008,7 +26008,7 @@
     },
     "packages/create": {
       "name": "@motion-canvas/create",
-      "version": "3.17.1",
+      "version": "3.17.2",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.8",
@@ -26018,10 +26018,10 @@
         "create-motion-canvas": "index.js"
       },
       "devDependencies": {
-        "@motion-canvas/2d": "^3.17.1",
-        "@motion-canvas/core": "^3.17.0",
-        "@motion-canvas/ui": "^3.17.0",
-        "@motion-canvas/vite-plugin": "^3.17.0"
+        "@motion-canvas/2d": "^3.17.2",
+        "@motion-canvas/core": "^3.17.2",
+        "@motion-canvas/ui": "^3.17.2",
+        "@motion-canvas/vite-plugin": "^3.17.2"
       }
     },
     "packages/docs": {
@@ -26144,13 +26144,13 @@
     },
     "packages/ffmpeg": {
       "name": "@motion-canvas/ffmpeg",
-      "version": "3.17.0",
+      "version": "3.17.2",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@ffprobe-installer/ffprobe": "^2.0.0",
-        "@motion-canvas/core": "^3.17.0",
-        "@motion-canvas/vite-plugin": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
+        "@motion-canvas/vite-plugin": "^3.17.2",
         "fluent-ffmpeg": "^2.1.2"
       },
       "devDependencies": {
@@ -26185,10 +26185,10 @@
     },
     "packages/player": {
       "name": "@motion-canvas/player",
-      "version": "3.17.0",
+      "version": "3.17.2",
       "license": "MIT",
       "devDependencies": {
-        "@motion-canvas/core": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
         "sass": "^1.58.0",
         "terser": "^5.16.1"
       }
@@ -26208,10 +26208,10 @@
     },
     "packages/ui": {
       "name": "@motion-canvas/ui",
-      "version": "3.17.0",
+      "version": "3.17.2",
       "license": "MIT",
       "dependencies": {
-        "@motion-canvas/core": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
         "@preact/signals": "^1.2.1",
         "preact": "^10.19.2"
       },
@@ -26235,7 +26235,7 @@
     },
     "packages/vite-plugin": {
       "name": "@motion-canvas/vite-plugin",
-      "version": "3.17.0",
+      "version": "3.17.2",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.1",
@@ -29917,9 +29917,9 @@
         "@codemirror/language": "^6.10.1",
         "@lezer/common": "^1.2.1",
         "@lezer/highlight": "^1.2.0",
-        "@motion-canvas/core": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
         "@motion-canvas/internal": "0.0.0",
-        "@motion-canvas/ui": "^3.17.0",
+        "@motion-canvas/ui": "^3.17.2",
         "@preact/signals": "^1.2.1",
         "clsx": "^2.0.0",
         "code-fns": "^0.8.2",
@@ -29959,10 +29959,10 @@
     "@motion-canvas/create": {
       "version": "file:packages/create",
       "requires": {
-        "@motion-canvas/2d": "^3.17.1",
-        "@motion-canvas/core": "^3.17.0",
-        "@motion-canvas/ui": "^3.17.0",
-        "@motion-canvas/vite-plugin": "^3.17.0",
+        "@motion-canvas/2d": "^3.17.2",
+        "@motion-canvas/core": "^3.17.2",
+        "@motion-canvas/ui": "^3.17.2",
+        "@motion-canvas/vite-plugin": "^3.17.2",
         "minimist": "^1.2.8",
         "prompts": "^2.4.2"
       }
@@ -30058,8 +30058,8 @@
       "requires": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@ffprobe-installer/ffprobe": "^2.0.0",
-        "@motion-canvas/core": "^3.17.0",
-        "@motion-canvas/vite-plugin": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
+        "@motion-canvas/vite-plugin": "^3.17.2",
         "@types/fluent-ffmpeg": "^2.1.21",
         "fluent-ffmpeg": "^2.1.2"
       }
@@ -30088,7 +30088,7 @@
     "@motion-canvas/player": {
       "version": "file:packages/player",
       "requires": {
-        "@motion-canvas/core": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
         "sass": "^1.58.0",
         "terser": "^5.16.1"
       }
@@ -30105,7 +30105,7 @@
     "@motion-canvas/ui": {
       "version": "file:packages/ui",
       "requires": {
-        "@motion-canvas/core": "^3.17.0",
+        "@motion-canvas/core": "^3.17.2",
         "@preact/preset-vite": "^2.7.0",
         "@preact/signals": "^1.2.1",
         "clsx": "^2.0.0",

--- a/packages/2d/CHANGELOG.md
+++ b/packages/2d/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+**Note:** Version bump only for package @motion-canvas/2d
+
+
+
+
+
 ## [3.17.1](https://github.com/motion-canvas/motion-canvas/compare/v3.17.0...v3.17.1) (2024-08-17)
 
 

--- a/packages/2d/package.json
+++ b/packages/2d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motion-canvas/2d",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "description": "A 2D renderer for Motion Canvas",
   "author": "motion-canvas",
   "homepage": "https://motioncanvas.io/",
@@ -29,7 +29,7 @@
   ],
   "devDependencies": {
     "@motion-canvas/internal": "0.0.0",
-    "@motion-canvas/ui": "^3.17.0",
+    "@motion-canvas/ui": "^3.17.2",
     "@preact/signals": "^1.2.1",
     "clsx": "^2.0.0",
     "jsdom": "^22.1.0",
@@ -40,7 +40,7 @@
     "@codemirror/language": "^6.10.1",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
-    "@motion-canvas/core": "^3.17.0",
+    "@motion-canvas/core": "^3.17.2",
     "code-fns": "^0.8.2",
     "mathjax-full": "^3.2.2",
     "parse-svg-path": "^0.1.2"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+
+### Bug Fixes
+
+* **core:** fix incorrect rollup ordering ([4743b92](https://github.com/motion-canvas/motion-canvas/commit/4743b92d10eed301b473434cc5cdde27882607bb))
+
+
+
+
+
 # [3.17.0](https://github.com/motion-canvas/motion-canvas/compare/v3.16.0...v3.17.0) (2024-08-13)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motion-canvas/core",
-  "version": "3.17.0",
+  "version": "3.17.2",
   "description": "Web-based tool for creating animations programmatically",
   "main": "lib/index.js",
   "author": "motion-canvas",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,11 @@
+// Custom order makes rollup arrange the ObjectMetaField correctly
+export * from './meta';
+
 export * from './app';
 export * from './decorators';
 export * from './events';
 export * from './flow';
 export * from './media';
-export * from './meta';
 export * from './plugin';
 export {default as DefaultPlugin} from './plugin/DefaultPlugin';
 export * from './scenes';

--- a/packages/core/src/meta/index.ts
+++ b/packages/core/src/meta/index.ts
@@ -4,15 +4,17 @@
  * @packageDocumentation
  */
 
+// Custom order makes rollup arrange the ObjectMetaField correctly
+export * from './MetaField';
+export * from './ObjectMetaField';
+
 export * from './BoolMetaField';
 export * from './ColorMetaField';
 export * from './EnumMetaField';
 export * from './ExporterMetaFile';
-export * from './MetaField';
 export * from './MetaFile';
 export * from './MetaOption';
 export * from './NumberMetaField';
-export * from './ObjectMetaField';
 export * from './RangeMetaField';
 export * from './StringMetaField';
 export * from './Vector2MetaField';

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+**Note:** Version bump only for package @motion-canvas/create
+
+
+
+
+
 ## [3.17.1](https://github.com/motion-canvas/motion-canvas/compare/v3.17.0...v3.17.1) (2024-08-17)
 
 **Note:** Version bump only for package @motion-canvas/create

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motion-canvas/create",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "description": "Quickly scaffold Motion Canvas projects",
   "main": "index.js",
   "author": "motion-canvas",
@@ -20,10 +20,10 @@
     "url": "https://github.com/motion-canvas/motion-canvas.git"
   },
   "devDependencies": {
-    "@motion-canvas/2d": "^3.17.1",
-    "@motion-canvas/core": "^3.17.0",
-    "@motion-canvas/ui": "^3.17.0",
-    "@motion-canvas/vite-plugin": "^3.17.0"
+    "@motion-canvas/2d": "^3.17.2",
+    "@motion-canvas/core": "^3.17.2",
+    "@motion-canvas/ui": "^3.17.2",
+    "@motion-canvas/vite-plugin": "^3.17.2"
   },
   "dependencies": {
     "minimist": "^1.2.8",

--- a/packages/ffmpeg/CHANGELOG.md
+++ b/packages/ffmpeg/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+**Note:** Version bump only for package @motion-canvas/ffmpeg
+
+
+
+
+
 # [3.17.0](https://github.com/motion-canvas/motion-canvas/compare/v3.16.0...v3.17.0) (2024-08-13)
 
 **Note:** Version bump only for package @motion-canvas/ffmpeg

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motion-canvas/ffmpeg",
-  "version": "3.17.0",
+  "version": "3.17.2",
   "description": "An FFmpeg video exporter for Motion Canvas",
   "main": "lib/server/index.js",
   "author": "motion-canvas",
@@ -27,8 +27,8 @@
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.0.0",
-    "@motion-canvas/core": "^3.17.0",
-    "@motion-canvas/vite-plugin": "^3.17.0",
+    "@motion-canvas/core": "^3.17.2",
+    "@motion-canvas/vite-plugin": "^3.17.2",
     "fluent-ffmpeg": "^2.1.2"
   }
 }

--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+**Note:** Version bump only for package @motion-canvas/player
+
+
+
+
+
 # [3.17.0](https://github.com/motion-canvas/motion-canvas/compare/v3.16.0...v3.17.0) (2024-08-13)
 
 **Note:** Version bump only for package @motion-canvas/player

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motion-canvas/player",
-  "version": "3.17.0",
+  "version": "3.17.2",
   "description": "A custom element for displaying animations made with Motion Canvas",
   "main": "dist/main.js",
   "types": "types/main.d.ts",
@@ -22,7 +22,7 @@
     "types"
   ],
   "devDependencies": {
-    "@motion-canvas/core": "^3.17.0",
+    "@motion-canvas/core": "^3.17.2",
     "sass": "^1.58.0",
     "terser": "^5.16.1"
   }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+
+### Bug Fixes
+
+* **vite-plugin, ui:** project file path on selection ([#1090](https://github.com/motion-canvas/motion-canvas/issues/1090)) ([f15b375](https://github.com/motion-canvas/motion-canvas/commit/f15b3753d47bcca8cd2d3f213f5624cf5e54142d))
+
+
+
+
+
 # [3.17.0](https://github.com/motion-canvas/motion-canvas/compare/v3.16.0...v3.17.0) (2024-08-13)
 
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motion-canvas/ui",
-  "version": "3.17.0",
+  "version": "3.17.2",
   "description": "A visual editor for Motion Canvas",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
@@ -26,7 +26,7 @@
     "tsconfig.plugin.json"
   ],
   "dependencies": {
-    "@motion-canvas/core": "^3.17.0",
+    "@motion-canvas/core": "^3.17.2",
     "@preact/signals": "^1.2.1",
     "preact": "^10.19.2"
   },

--- a/packages/ui/src/components/playback/PlaybackControls.tsx
+++ b/packages/ui/src/components/playback/PlaybackControls.tsx
@@ -80,6 +80,9 @@ export function PlaybackControls() {
           {value: 1, text: 'x1'},
           {value: 1.5, text: 'x1.5'},
           {value: 2, text: 'x2'},
+          {value: 3, text: 'x3'},
+          {value: 3.5, text: 'x3.5'},
+          {value: 4, text: 'x4'},
         ]}
         value={state.speed}
         onChange={speed => player.setSpeed(speed)}

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.17.2](https://github.com/motion-canvas/motion-canvas/compare/v3.17.1...v3.17.2) (2024-12-14)
+
+
+### Bug Fixes
+
+* **vite-plugin, ui:** project file path on selection ([#1090](https://github.com/motion-canvas/motion-canvas/issues/1090)) ([f15b375](https://github.com/motion-canvas/motion-canvas/commit/f15b3753d47bcca8cd2d3f213f5624cf5e54142d))
+
+
+
+
+
 # [3.17.0](https://github.com/motion-canvas/motion-canvas/compare/v3.16.0...v3.17.0) (2024-08-13)
 
 

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motion-canvas/vite-plugin",
-  "version": "3.17.0",
+  "version": "3.17.2",
   "description": "A Vite plugin for Motion Canvas projects",
   "main": "lib/index.js",
   "author": "motion-canvas",


### PR DESCRIPTION
## Summary
- Adds x3, x3.5, and x4 options to the playback speed dropdown in the editor
- Useful for quickly scrubbing through longer animations during development

## Test plan
- Open the editor, click the playback speed dropdown
- Verify x3, x3.5, x4 options appear alongside existing options
- Play an animation at each new speed and confirm it plays correctly