### PR TITLE
feat(ffmpeg): add an ability to export scene by scene and in higher quality

### DIFF
--- a/packages/core/src/scenes/Sounds.ts
+++ b/packages/core/src/scenes/Sounds.ts
@@ -14,6 +14,8 @@ export interface SoundSettings {
 export interface Sound extends SoundSettings {
   offset: number;
   realPlaybackRate: number;
+  sceneName?: string;
+  sceneFirstFrame?: number;
 }
 
 export class SoundBuilder {
@@ -117,6 +119,8 @@ export class Sounds {
         Math.pow(2, (settings.detune ?? 0) / 1200) *
         (settings.playbackRate ?? 1),
       ...settings,
+      sceneName: this.scene.name,
+      sceneFirstFrame: this.scene.firstFrame,
     });
   }
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "module": "esnext",
     "target": "es2020",
+    "lib": ["es2020", "dom", "es2022.intl"],
     "allowJs": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,

--- a/packages/ffmpeg/client/FFmpegExporterClient.ts
+++ b/packages/ffmpeg/client/FFmpegExporterClient.ts
@@ -64,6 +64,8 @@ export class FFmpegExporterClient implements Exporter {
         !project.audio,
       ),
       audioSampleRate: new NumberMetaField('audio sample rate', 48000),
+      splitByScene: new BoolMetaField('split by scene', true),
+      highQuality: new BoolMetaField('high quality (larger)', false),
     });
   }
 
@@ -107,7 +109,7 @@ export class FFmpegExporterClient implements Exporter {
     canvas: HTMLCanvasElement,
     _frame: number,
     _sceneFrame: number,
-    _sceneName: string,
+    sceneName: string,
     _signal: AbortSignal,
     context: CanvasRenderingContext2D,
   ): Promise<void> {
@@ -121,7 +123,8 @@ export class FFmpegExporterClient implements Exporter {
 
     const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
     this.concurrentFrames++;
-    this.invoke('handleFrame', data, 'octet-stream')
+    await this.invoke('reportScene', {sceneName: sceneName});
+    await this.invoke('handleFrame', data, 'octet-stream')
       .then(() => {
         this.concurrentFrames--;
       })


### PR DESCRIPTION
This PR adds two things:
* the ability to export a video scene-by-scene, similarly to how the png exporter allows grouping the pngs by scene (but also with sound).
* an option for rendering in a higher quality, more suitable for passing the rendered output to a video editor that re-renders it again.

This is a redo of #1209 with a correct branch.